### PR TITLE
Refactor evaluators and SparseEncoder to use max_active_dims

### DIFF
--- a/docs/package_reference/sparse_encoder/SparseEncoder.md
+++ b/docs/package_reference/sparse_encoder/SparseEncoder.md
@@ -5,7 +5,7 @@
 .. autoclass:: sentence_transformers.sparse_encoder.SparseEncoder
    :members:
    :inherited-members: 
-   :exclude-members: fit, old_fit, save, save_to_hub, add_module, append, apply, buffers, children, extra_repr, forward, get_buffer, get_extra_state, get_parameter, get_submodule, ipu, load_state_dict, modules, named_buffers, named_children, named_modules, named_parameters, parameters, register_backward_hook, register_buffer, register_forward_hook, register_forward_pre_hook, register_full_backward_hook, register_full_backward_pre_hook, register_load_state_dict_post_hook, register_module, register_parameter, register_state_dict_pre_hook, requires_grad_, set_extra_state, share_memory, state_dict, to_empty, type, xpu, zero_grad
+   :exclude-members: fit, old_fit, save, save_to_hub, add_module, append, apply, buffers, children, extra_repr, forward, get_buffer, get_extra_state, get_parameter, get_submodule, ipu, load_state_dict, modules, named_buffers, named_children, named_modules, named_parameters, parameters, register_backward_hook, register_buffer, register_forward_hook, register_forward_pre_hook, register_full_backward_hook, register_full_backward_pre_hook, register_load_state_dict_post_hook, register_module, register_parameter, register_state_dict_pre_hook, requires_grad_, set_extra_state, share_memory, state_dict, to_empty, type, xpu, zero_grad, truncate_sentence_embeddings
 ```
 
 ## SparseEncoderModelCardData

--- a/docs/sparse_encoder/usage/usage.rst
+++ b/docs/sparse_encoder/usage/usage.rst
@@ -12,10 +12,10 @@ Once you have `installed <../../installation.html>`_ Sentence Transformers, you 
 
 .. sidebar:: Documentation
 
-   1. :class:`SparseEncoder <sentence_transformers.SparseEncoder>`
-   2. :meth:`SparseEncoder.encode <sentence_transformers.SparseEncoder.encode>`
-   3. :meth:`SparseEncoder.similarity <sentence_transformers.SparseEncoder.similarity>`
-   4. :meth:`SparseEncoder.get_sparsity_stats <sentence_transformers.SparseEncoder.get_sparsity_stats>`
+   1. :class:`SparseEncoder <sentence_transformers.sparse_encoder.SparseEncoder>`
+   2. :meth:`SparseEncoder.encode <sentence_transformers.sparse_encoder.SparseEncoder.encode>`
+   3. :meth:`SparseEncoder.similarity <sentence_transformers.sparse_encoder.SparseEncoder.similarity>`
+   4. :meth:`SparseEncoder.get_sparsity_stats <sentence_transformers.sparse_encoder.SparseEncoder.get_sparsity_stats>`
 
 ::
 

--- a/examples/sentence_transformer/training/matryoshka/matryoshka_eval_stsb.py
+++ b/examples/sentence_transformer/training/matryoshka/matryoshka_eval_stsb.py
@@ -160,8 +160,8 @@ if __name__ == "__main__":
         for dim in tqdm(DIMENSIONS, desc=f"Evaluating {model_name}"):
             output_path = os.path.join(model_name, f"dim-{dim}")
             os.makedirs(output_path)
-            with model.truncate_sentence_embeddings(dim):
-                score = test_evaluator(model, output_path=output_path)
+            test_evaluator.truncate_dim = dim
+            score = test_evaluator(model, output_path=output_path)
             print(f"Saved results to {output_path}")
             dim_to_score[dim] = score
         model_name_to_dim_to_score[model_name] = dim_to_score

--- a/examples/sparse_encoder/applications/computing_embeddings/README.rst
+++ b/examples/sparse_encoder/applications/computing_embeddings/README.rst
@@ -92,6 +92,98 @@ Each model has a maximum sequence length under ``model.max_seq_length``, which i
 
    You cannot increase the length higher than what is maximally supported by the respective transformer model. Also note that if a model was trained on short texts, the representations for long texts might not be that good.
 
+Controlling Sparsity with max_active_dims
+-----------------------------------------
+
+For sparse models, you can control the maximum number of active dimensions (non-zero values) in the output embeddings using the ``max_active_dims`` parameter. This is particularly useful for:
+
+1. Reducing memory usage and storage requirements
+2. Improving search efficiency in production systems
+3. Controlling the trade-off between accuracy and performance
+
+You can specify ``max_active_dims`` either when initializing the model or during encoding:
+
+::
+
+   from sentence_transformers import SparseEncoder
+
+   # Initialize the SPLADE model
+   model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
+
+   # Embed a list of sentences
+   sentences = [
+      "This framework generates embeddings for each input sentence",
+      "Sentences are passed as a list of string.",
+      "The quick brown fox jumps over the lazy dog.",
+   ]
+
+   # Generate embeddings
+   embeddings = model.encode(sentences)
+
+   # Print embedding sim and sparsity
+   print(f"Embedding dim: {model.get_sentence_embedding_dimension()}")
+
+   stats = model.get_sparsity_stats(embeddings)
+   print(f"Embedding sparsity: {stats}")
+   print(f"Average non-zero dimensions: {stats['row_non_zero_mean']:.2f}")
+   print(f"Sparsity percentage: {stats['row_sparsity_mean']:.2%}")
+
+
+   """
+   Embedding dim: 30522
+   Embedding sparsity: {'num_rows': 3, 'num_cols': 30522, 'row_non_zero_mean': 56.66666793823242, 'row_sparsity_mean': 0.9981433749198914}
+   Average non-zero dimensions: 56.67
+   Sparsity percentage: 99.81%
+   """
+   
+   # Example of using max_active_dims during encoding
+   print("\n--- Using max_active_dims during encoding ---")
+   # Generate embeddings with limited active dimensions
+   embeddings_limited = model.encode(sentences, max_active_dims=32)
+   stats_limited = model.get_sparsity_stats(embeddings_limited)
+   print(f"Limited embedding sparsity: {stats_limited}")
+   print(f"Average non-zero dimensions: {stats_limited['row_non_zero_mean']:.2f}")
+   print(f"Sparsity percentage: {stats_limited['row_sparsity_mean']:.2%}")
+
+   """
+   --- Using max_active_dims during encoding ---
+   Limited embedding sparsity: {'num_rows': 3, 'num_cols': 30522, 'row_non_zero_mean': 32.0, 'row_sparsity_mean': 0.9989516139030457}
+   Average non-zero dimensions: 32.00
+   Sparsity percentage: 99.90%
+   """
+
+When you set ``max_active_dims``, the model will keep only the top-K dimensions with the highest values and set all other values to zero. This ensures your embeddings maintain a controlled level of sparsity while preserving the most important semantic information.
+
+.. note::
+
+   Setting a very low ``max_active_dims`` value may reduce the quality of search results. The optimal value depends on your specific use case and dataset. Common values range from 128 to 512 dimensions, like dense embeddings dimensions.
+
+
+One of the key benefits of controlling sparsity with ``max_active_dims`` is reduced memory usage. Here's an example showing the memory savings:
+
+::
+
+   # Compare memory usage between default and limited active dimensions
+   print("\n--- Comparing memory usage ---")
+   def get_memory_size(tensor):
+       if tensor.is_sparse:
+           # For sparse tensors, only count non-zero elements
+           return (tensor._values().element_size() * tensor._values().nelement() + 
+                  tensor._indices().element_size() * tensor._indices().nelement())
+       else:
+           return tensor.element_size() * tensor.nelement()
+
+   print(f"Original embeddings memory: {get_memory_size(embeddings) / 1024:.2f} KB")
+   print(f"Embeddings with max_active_dims=32 memory: {get_memory_size(embeddings_limited) / 1024:.2f} KB")
+
+   """
+   --- Comparing memory usage ---
+   Original embeddings memory: 3.32 KB
+   Embeddings with max_active_dims=32 memory: 1.88 KB
+   """
+
+As shown in the example, limiting active dimensions to 32 reduced memory usage by approximately 43%. This efficiency becomes even more significant when working with large document collections but need to be put in balance with the possible loss of quality of the embeddings representations.
+
 Interpretability with SPLADE Models
 ----------------------------------
 

--- a/examples/sparse_encoder/applications/computing_embeddings/README.rst
+++ b/examples/sparse_encoder/applications/computing_embeddings/README.rst
@@ -217,16 +217,11 @@ When using SPLADE models, a key advantage is interpretability. You can easily vi
       token_scores = ", ".join([f'("{token.strip()}", {value:.2f})' for token, value in token_weights[i]])
       print(f"{i}: {sentence} -> Top tokens:  {token_scores}")
 
-Example output:
-
-::
-
    """
    Top tokens 10 for each text:
       0: This framework generates embeddings for each input sentence -> Top tokens:  ("framework", 2.19), ("##bed", 2.12), ("input", 1.99), ("each", 1.60), ("em", 1.58), ("sentence", 1.49), ("generate", 1.42), ("##ding", 1.33), ("sentences", 1.10), ("create", 0.93)
       1: Sentences are passed as a list of string. -> Top tokens:  ("string", 2.72), ("pass", 2.24), ("sentences", 2.15), ("passed", 2.07), ("sentence", 1.90), ("strings", 1.86), ("list", 1.84), ("lists", 1.49), ("as", 1.18), ("passing", 0.73)
       2: The quick brown fox jumps over the lazy dog. -> Top tokens:  ("lazy", 2.18), ("fox", 1.67), ("brown", 1.56), ("over", 1.52), ("dog", 1.50), ("quick", 1.49), ("jump", 1.39), ("dogs", 1.25), ("foxes", 0.99), ("jumping", 0.84)
    """
-
    
 This interpretability helps in understanding why certain documents match or don't match in search applications, and provides transparency into the model's behavior.

--- a/examples/sparse_encoder/applications/computing_embeddings/README.rst
+++ b/examples/sparse_encoder/applications/computing_embeddings/README.rst
@@ -146,7 +146,7 @@ When you set ``max_active_dims``, the model will keep only the top-K dimensions 
 
 .. note::
 
-   Setting a very low ``max_active_dims`` value may reduce the quality of search results. The optimal value depends on your specific use case and dataset. Common values range from 128 to 512 dimensions, like dense embeddings dimensions.
+   Setting a very low ``max_active_dims`` value may reduce the quality of search results. The optimal value depends on your specific use case and dataset.
 
 
 One of the key benefits of controlling sparsity with ``max_active_dims`` is reduced memory usage. Here's an example showing the memory savings:

--- a/examples/sparse_encoder/training/train_nli.py
+++ b/examples/sparse_encoder/training/train_nli.py
@@ -56,7 +56,7 @@ def main():
                 scores=stsb_eval_dataset["score"],
                 main_similarity=SimilarityFunction.COSINE,
                 name=f"sts-dev-{k_dim}",
-                truncate_dim=k_dim,
+                max_active_dims=k_dim,
             )
         )
     dev_evaluator = SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[-1])

--- a/examples/sparse_encoder/training/train_nli.py
+++ b/examples/sparse_encoder/training/train_nli.py
@@ -107,7 +107,7 @@ def main():
                 scores=test_dataset["score"],
                 main_similarity=SimilarityFunction.COSINE,
                 name=f"sts-test-{k_dim}",
-                truncate_dim=k_dim,
+                max_active_dims=k_dim,
             )
         )
     test_evaluator = SequentialEvaluator(evaluators)

--- a/examples/sparse_encoder/training/train_nq.py
+++ b/examples/sparse_encoder/training/train_nq.py
@@ -5,6 +5,7 @@ import logging
 from datasets import load_dataset
 
 from sentence_transformers import SparseEncoder, SparseEncoderTrainer, SparseEncoderTrainingArguments
+from sentence_transformers.evaluation import SequentialEvaluator
 from sentence_transformers.models import Pooling, Transformer
 from sentence_transformers.sparse_encoder import evaluation, losses, models
 from sentence_transformers.training_args import BatchSamplers
@@ -22,7 +23,7 @@ def main():
     csr_sparsity = models.CSRSparsity(
         input_dim=transformer.get_word_embedding_dimension(),
         hidden_dim=4 * transformer.get_word_embedding_dimension(),
-        k=256,  # Number of top values to keep
+        k=8,  # Number of top values to keep
         k_aux=512,  # Number of top values for auxiliary loss
     )
 
@@ -49,8 +50,8 @@ def main():
     # 4. Define an evaluator for use during training. This is useful to keep track of alongside the evaluation loss.
     evaluators = []
     for k_dim in [16, 32, 64, 128, 256]:
-        evaluators.append(evaluation.SparseNanoBEIREvaluator(["msmarco", "nfcorpus", "nq"], truncate_dim=k_dim))
-    dev_evaluator = evaluation.SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[-1])
+        evaluators.append(evaluation.SparseNanoBEIREvaluator(["msmarco", "nfcorpus", "nq"], max_active_dims=k_dim))
+    dev_evaluator = SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[-1])
     dev_evaluator(model)
 
     # Set up training arguments

--- a/examples/sparse_encoder/training/train_nq.py
+++ b/examples/sparse_encoder/training/train_nq.py
@@ -23,7 +23,7 @@ def main():
     csr_sparsity = models.CSRSparsity(
         input_dim=transformer.get_word_embedding_dimension(),
         hidden_dim=4 * transformer.get_word_embedding_dimension(),
-        k=8,  # Number of top values to keep
+        k=256,  # Number of top values to keep
         k_aux=512,  # Number of top values for auxiliary loss
     )
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -711,7 +711,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                 if self.device.type == "hpu":
                     out_features = copy.deepcopy(out_features)
 
-                if self.truncate_dim:
+                if truncate_dim:
                     out_features["sentence_embedding"] = truncate_embeddings(
                         out_features["sentence_embedding"], truncate_dim
                     )

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -161,6 +161,8 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
             #         [0.0492, 0.0421, 1.0000]])
     """
 
+    model_card_data_class = SentenceTransformerModelCardData
+
     def __init__(
         self,
         model_name_or_path: str | None = None,
@@ -188,7 +190,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         self.similarity_fn_name = similarity_fn_name
         self.trust_remote_code = trust_remote_code
         self.truncate_dim = truncate_dim
-        self.model_card_data = model_card_data or SentenceTransformerModelCardData()
+        self.model_card_data = model_card_data or self.model_card_data_class()
         self.module_kwargs = None
         self._model_card_vars = {}
         self._model_card_text = None

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -87,8 +87,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         local_files_only (bool, optional): Whether or not to only look at local files (i.e., do not try to download the model).
         token (bool or str, optional): Hugging Face authentication token to download private models.
         use_auth_token (bool or str, optional): Deprecated argument. Please use `token` instead.
-        truncate_dim (int, optional): The dimension to truncate sentence embeddings to. `None` does no truncation. Truncation is
-            only applicable during inference when :meth:`SentenceTransformer.encode` is called.
+        truncate_dim (int, optional): The dimension to truncate sentence embeddings to. Defaults to None.
         model_kwargs (Dict[str, Any], optional): Additional model configuration parameters to be passed to the Hugging Face Transformers model.
             Particularly useful options are:
 
@@ -584,8 +583,12 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
             device (str, optional): Which :class:`torch.device` to use for the computation. Defaults to None.
             normalize_embeddings (bool, optional): Whether to normalize returned vectors to have length 1. In that case,
                 the faster dot-product (util.dot_score) instead of cosine similarity can be used. Defaults to False.
-            truncate_dim (int, optional): The dimension to truncate sentence embeddings to. `None` means we will used the value of the
-                model's config. Defaults to None.
+            truncate_dim (int, optional): The dimension to truncate sentence embeddings to.
+                Truncation is especially interesting for `Matryoshka models <https://sbert.net/examples/sentence_transformer/training/matryoshka/README.html>`_,
+                i.e. models that are trained to still produce useful embeddings even if the embedding dimension is reduced.
+                Truncated embeddings require less memory and are faster to perform retrieval with, but note that inference
+                is just as fast, and the embedding performance is worse than the full embeddings. If None, the ``truncate_dim``
+                from the model initialization is used. Defaults to None.
 
         Returns:
             Union[List[Tensor], ndarray, Tensor]: By default, a 2d numpy array with shape [num_inputs, output_dimension] is returned.
@@ -1029,8 +1032,12 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                 semantic search, among other tasks. Defaults to "float32".
             normalize_embeddings (bool): Whether to normalize returned vectors to have length 1. In that case,
                 the faster dot-product (util.dot_score) instead of cosine similarity can be used. Defaults to False.
-            truncate_dim (int, optional): The dimension to truncate sentence embeddings to. `None` means we will used the value of the
-                model's config. Defaults to None.
+            truncate_dim (int, optional): The dimension to truncate sentence embeddings to.
+                Truncation is especially interesting for `Matryoshka models <https://sbert.net/examples/sentence_transformer/training/matryoshka/README.html>`_,
+                i.e. models that are trained to still produce useful embeddings even if the embedding dimension is reduced.
+                Truncated embeddings require less memory and are faster to perform retrieval with, but note that inference
+                is just as fast, and the embedding performance is worse than the full embeddings. If None, the ``truncate_dim``
+                from the model initialization is used. Defaults to None.
 
         Returns:
             np.ndarray: A 2D numpy array with shape [num_inputs, output_dimension].
@@ -1121,7 +1128,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                     convert_to_numpy=True,
                     batch_size=batch_size,
                     normalize_embeddings=normalize_embeddings,
-                    truncate_dim=model.truncate_dim,
+                    truncate_dim=truncate_dim,
                 )
 
                 results_queue.put([chunk_id, embeddings])

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -163,9 +162,8 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
 
         logger.info(f"EmbeddingSimilarityEvaluator: Evaluating the model on the {self.name} dataset{out_txt}:")
 
-        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-            embeddings1 = self.embed_inputs(model, self.sentences1)
-            embeddings2 = self.embed_inputs(model, self.sentences2)
+        embeddings1 = self.embed_inputs(model, self.sentences1)
+        embeddings2 = self.embed_inputs(model, self.sentences2)
         # Binary and ubinary embeddings are packed, so we need to unpack them for the distance metrics
         if self.precision == "binary":
             embeddings1 = (embeddings1 + 128).astype(np.uint8)
@@ -253,6 +251,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
             convert_to_numpy=True,
             precision=self.precision,
             normalize_embeddings=bool(self.precision),
+            truncate_dim=self.truncate_dim,
             **kwargs,
         )
 

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import heapq
 import logging
 import os
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Callable
 
 import numpy as np
@@ -294,13 +293,12 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         )
 
         # Compute embedding for the queries
-        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-            query_embeddings = self.embed_inputs(
-                model,
-                self.queries,
-                prompt_name=self.query_prompt_name,
-                prompt=self.query_prompt,
-            )
+        query_embeddings = self.embed_inputs(
+            model,
+            self.queries,
+            prompt_name=self.query_prompt_name,
+            prompt=self.query_prompt,
+        )
 
         queries_result_list = {}
         for name in self.score_functions:
@@ -314,17 +312,12 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
             # Encode chunk of corpus
             if corpus_embeddings is None:
-                with (
-                    nullcontext()
-                    if self.truncate_dim is None
-                    else corpus_model.truncate_sentence_embeddings(self.truncate_dim)
-                ):
-                    sub_corpus_embeddings = self.embed_inputs(
-                        corpus_model,
-                        self.corpus[corpus_start_idx:corpus_end_idx],
-                        prompt_name=self.corpus_prompt_name,
-                        prompt=self.corpus_prompt,
-                    )
+                sub_corpus_embeddings = self.embed_inputs(
+                    corpus_model,
+                    self.corpus[corpus_start_idx:corpus_end_idx],
+                    prompt_name=self.corpus_prompt_name,
+                    prompt=self.corpus_prompt,
+                )
             else:
                 sub_corpus_embeddings = corpus_embeddings[corpus_start_idx:corpus_end_idx]
 
@@ -389,6 +382,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_tensor=True,
+            truncate_dim=self.truncate_dim,
             **kwargs,
         )
 

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -81,12 +80,8 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             self.csv_headers.append(f"{src_lang}-{trg_lang}")
 
         all_source_sentences = list(all_source_sentences)
-        with (
-            nullcontext()
-            if self.truncate_dim is None
-            else teacher_model.truncate_sentence_embeddings(self.truncate_dim)
-        ):
-            all_src_embeddings = self.embed_inputs(teacher_model, all_source_sentences)
+
+        all_src_embeddings = self.embed_inputs(teacher_model, all_source_sentences)
         self.teacher_embeddings = {sent: emb for sent, emb in zip(all_source_sentences, all_src_embeddings)}
 
     def __call__(
@@ -99,8 +94,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             src_sentences, trg_sentences = self.data[(src_lang, trg_lang)]
 
             src_embeddings = np.asarray([self.teacher_embeddings[sent] for sent in src_sentences])
-            with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-                trg_embeddings = np.asarray(self.embed_inputs(model, trg_sentences))
+            trg_embeddings = np.asarray(self.embed_inputs(model, trg_sentences))
 
             mse = ((src_embeddings - trg_embeddings) ** 2).mean()
             mse *= 100
@@ -135,6 +129,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             sentences,
             batch_size=self.batch_size,
             convert_to_numpy=True,
+            truncate_dim=self.truncate_dim,
             **kwargs,
         )
 

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -172,12 +172,12 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         pairs_list = paraphrase_mining(
             model,
             self.sentences,
-            self.show_progress_bar,
-            self.batch_size,
-            self.query_chunk_size,
-            self.corpus_chunk_size,
-            self.max_pairs,
-            self.top_k,
+            show_progress_bar=self.show_progress_bar,
+            batch_size=self.batch_size,
+            query_chunk_size=self.query_chunk_size,
+            corpus_chunk_size=self.corpus_chunk_size,
+            max_pairs=self.max_pairs,
+            top_k=self.top_k,
             truncate_dim=self.truncate_dim,
         )
 

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -4,7 +4,6 @@ import csv
 import logging
 import os
 from collections import defaultdict
-from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
@@ -170,17 +169,17 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         logger.info(f"Paraphrase Mining Evaluation of the model on the {self.name} dataset{out_txt}:")
 
         # Compute embedding for the sentences
-        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-            pairs_list = paraphrase_mining(
-                model,
-                self.sentences,
-                self.show_progress_bar,
-                self.batch_size,
-                self.query_chunk_size,
-                self.corpus_chunk_size,
-                self.max_pairs,
-                self.top_k,
-            )
+        pairs_list = paraphrase_mining(
+            model,
+            self.sentences,
+            self.show_progress_bar,
+            self.batch_size,
+            self.query_chunk_size,
+            self.corpus_chunk_size,
+            self.max_pairs,
+            self.top_k,
+            truncate_dim=self.truncate_dim,
+        )
 
         logger.info("Number of candidate pairs: " + str(len(pairs_list)))
 

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Callable
 
 import numpy as np
@@ -228,18 +227,18 @@ class RerankingEvaluator(SentenceEvaluator):
         all_ndcg_scores = []
         all_ap_scores = []
 
-        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-            all_query_embs = self.embed_inputs(
-                model, [sample["query"] for sample in self.samples], show_progress_bar=self.show_progress_bar
-            )
+        all_query_embs = self.embed_inputs(
+            model, [sample["query"] for sample in self.samples], show_progress_bar=self.show_progress_bar
+        )
 
-            all_docs = []
+        all_docs = []
 
-            for sample in self.samples:
-                all_docs.extend(sample["positive"])
-                all_docs.extend(sample["negative"])
+        for sample in self.samples:
+            all_docs.extend(sample["positive"])
+            all_docs.extend(sample["negative"])
 
-            all_docs_embs = self.embed_inputs(model, all_docs, show_progress_bar=self.show_progress_bar)
+        all_docs_embs = self.embed_inputs(model, all_docs, show_progress_bar=self.show_progress_bar)
+
         # Compute scores
         query_idx, docs_idx = 0, 0
         for instance in self.samples:
@@ -307,9 +306,8 @@ class RerankingEvaluator(SentenceEvaluator):
             docs = positive + negative
             is_relevant = [1] * len(positive) + [0] * len(negative)
 
-            with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-                query_emb = self.embed_inputs(model, [query], show_progress_bar=False)
-                docs_emb = self.embed_inputs(model, docs, show_progress_bar=False)
+            query_emb = self.embed_inputs(model, [query], show_progress_bar=False)
+            docs_emb = self.embed_inputs(model, docs, show_progress_bar=False)
 
             pred_scores = self.similarity_fct(query_emb, docs_emb)
             if len(pred_scores.shape) > 1:
@@ -350,6 +348,7 @@ class RerankingEvaluator(SentenceEvaluator):
             batch_size=self.batch_size,
             show_progress_bar=show_progress_bar,
             convert_to_tensor=True,
+            truncate_dim=self.truncate_dim,
             **kwargs,
         )
 

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -115,9 +114,8 @@ class TranslationEvaluator(SentenceEvaluator):
 
         logger.info(f"Evaluating translation matching Accuracy of the model on the {self.name} dataset{out_txt}:")
 
-        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-            embeddings1 = torch.stack(self.embed_inputs(model, self.source_sentences))
-            embeddings2 = torch.stack(self.embed_inputs(model, self.target_sentences))
+        embeddings1 = torch.stack(self.embed_inputs(model, self.source_sentences))
+        embeddings2 = torch.stack(self.embed_inputs(model, self.target_sentences))
 
         cos_sims = pytorch_cos_sim(embeddings1, embeddings2).detach().cpu().numpy()
 
@@ -182,6 +180,7 @@ class TranslationEvaluator(SentenceEvaluator):
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_numpy=False,
+            truncate_dim=self.truncate_dim,
             **kwargs,
         )
 

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Literal
 
 from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
@@ -177,10 +176,9 @@ class TripletEvaluator(SentenceEvaluator):
 
         logger.info(f"TripletEvaluator: Evaluating the model on the {self.name} dataset{out_txt}:")
 
-        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
-            embeddings_anchors = self.embed_inputs(model, self.anchors)
-            embeddings_positives = self.embed_inputs(model, self.positives)
-            embeddings_negatives = self.embed_inputs(model, self.negatives)
+        embeddings_anchors = self.embed_inputs(model, self.anchors)
+        embeddings_positives = self.embed_inputs(model, self.positives)
+        embeddings_negatives = self.embed_inputs(model, self.negatives)
 
         if not self.similarity_fn_names:
             self.similarity_fn_names = [model.similarity_fn_name]
@@ -259,6 +257,7 @@ class TripletEvaluator(SentenceEvaluator):
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_numpy=True,
+            truncate_dim=self.truncate_dim,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -307,7 +307,7 @@ class SparseEncoder(SentenceTransformer):
             with torch.no_grad():
                 out_features = self.forward(features, **kwargs)
 
-                if self.max_active_dims:
+                if max_active_dims:
                     out_features["sentence_embedding"] = select_max_active_dims(
                         out_features["sentence_embedding"], max_active_dims=max_active_dims
                     )

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -652,7 +652,7 @@ class SparseEncoder(SentenceTransformer):
     def truncate_sentence_embeddings(self, truncate_dim: int | None) -> Iterator[None]:
         raise NotImplementedError(
             "SparseEncoder does not support truncating sentence embeddings. "
-            "Use the `max_active_dims` parameter in the encode method instead."
+            "Use the `max_active_dims` parameter in the encode method instead if you want to limit the embedding memory usage."
         )
 
     def save(

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -22,7 +22,7 @@ from sentence_transformers.SentenceTransformer import SentenceTransformer
 from sentence_transformers.similarity_functions import SimilarityFunction
 from sentence_transformers.sparse_encoder.model_card import SparseEncoderModelCardData
 from sentence_transformers.sparse_encoder.models import CSRSparsity, MLMTransformer, SpladePooling
-from sentence_transformers.util import batch_to_device, truncate_embeddings_for_sparse
+from sentence_transformers.util import batch_to_device, select_max_active_dims
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +57,8 @@ class SparseEncoder(SentenceTransformer):
         local_files_only (bool, optional): Whether or not to only look at local files (i.e., do not try to download the model).
         token (bool or str, optional): Hugging Face authentication token to download private models.
         use_auth_token (bool or str, optional): Deprecated argument. Please use `token` instead.
-        truncate_dim (int, optional): The dimension to truncate sentence embeddings to. `None` does no truncation. Truncation is
-            only applicable during inference when :meth:`SparseEncoder.encode` is called.
+        max_active_dims (int, optional): The maximum number of active dimensions in the output of the model. Defaults to None. This mean there will be no
+            limit on the number of active dimensions and can be risky when indexing the embeddings.
         model_kwargs (Dict[str, Any], optional): Additional model configuration parameters to be passed to the Hugging Face Transformers model.
             Particularly useful options are:
 
@@ -146,7 +146,7 @@ class SparseEncoder(SentenceTransformer):
         local_files_only: bool = False,
         token: bool | str | None = None,
         use_auth_token: bool | str | None = None,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
         model_kwargs: dict[str, Any] | None = None,
         tokenizer_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
@@ -166,13 +166,14 @@ class SparseEncoder(SentenceTransformer):
             local_files_only=local_files_only,
             token=token,
             use_auth_token=use_auth_token,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
             model_kwargs=model_kwargs,
             tokenizer_kwargs=tokenizer_kwargs,
             config_kwargs=config_kwargs,
             model_card_data=model_card_data,
             backend=backend,
         )
+        self.max_active_dims = max_active_dims
         self.model_card_data = model_card_data or SparseEncoderModelCardData()
         self.model_card_data.register_model(self)
 
@@ -188,6 +189,7 @@ class SparseEncoder(SentenceTransformer):
         convert_to_sparse_tensor: bool = True,
         save_to_cpu: bool = False,
         device: str | None = None,
+        max_active_dims: int | None = None,
         **kwargs: Any,
     ) -> list[Tensor] | np.ndarray | Tensor | dict[str, Tensor] | list[dict[str, Tensor]]:
         """
@@ -215,6 +217,8 @@ class SparseEncoder(SentenceTransformer):
             save_to_cpu (bool, optional):  Whether the output should be moved to cpu or stay on the device it has been computed on.
                 Defaults to False
             device (str, optional): Which :class:`torch.device` to use for the computation, if None current device will be use. Defaults to None.
+            max_active_dims (int, optional): The maximum number of active dimensions in the output of the model. `None` means we will used the value of the
+                model's config. Defaults to None.
 
         Returns:
             Union[List[Tensor], ndarray, Tensor]: By default, a 2d numpy array with shape [num_inputs, output_dimension] is returned.
@@ -288,6 +292,8 @@ class SparseEncoder(SentenceTransformer):
 
         self.to(device)
 
+        max_active_dims = max_active_dims if max_active_dims is not None else self.max_active_dims
+
         all_embeddings = []
         length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
         sentences_sorted = [sentences[idx] for idx in length_sorted_idx]
@@ -300,9 +306,11 @@ class SparseEncoder(SentenceTransformer):
 
             with torch.no_grad():
                 out_features = self.forward(features, **kwargs)
-                out_features["sentence_embedding"] = truncate_embeddings_for_sparse(
-                    out_features["sentence_embedding"], truncate_dim=self.truncate_dim
-                )
+
+                if self.max_active_dims:
+                    out_features["sentence_embedding"] = select_max_active_dims(
+                        out_features["sentence_embedding"], max_active_dims=max_active_dims
+                    )
 
                 if output_value == "token_embeddings":
                     embeddings = []
@@ -508,6 +516,7 @@ class SparseEncoder(SentenceTransformer):
         batch_size: int = 32,
         chunk_size: int = None,
         show_progress_bar: bool | None = None,
+        max_active_dims: int | None = None,
     ) -> Tensor:
         """
         Encodes a list of sentences using multiple processes and GPUs via
@@ -531,6 +540,8 @@ class SparseEncoder(SentenceTransformer):
             chunk_size (int): Sentences are chunked and sent to the individual processes. If None, it determines a
                 sensible size. Defaults to None.
             show_progress_bar (bool, optional): Whether to output a progress bar when encode sentences. Defaults to None.
+            max_active_dims (int, optional): The maximum number of active dimensions in the output of the model. `None` means we will used the value of the
+                model's config. Defaults to None.
 
         Returns:
             Tensor: A 2D tensor with shape [num_inputs, output_dimension].
@@ -576,12 +587,12 @@ class SparseEncoder(SentenceTransformer):
         for sentence in sentences:
             chunk.append(sentence)
             if len(chunk) >= chunk_size:
-                input_queue.put([last_chunk_id, batch_size, chunk, prompt_name, prompt])
+                input_queue.put([last_chunk_id, batch_size, chunk, prompt_name, prompt, max_active_dims])
                 last_chunk_id += 1
                 chunk = []
 
         if len(chunk) > 0:
-            input_queue.put([last_chunk_id, batch_size, chunk, prompt_name, prompt])
+            input_queue.put([last_chunk_id, batch_size, chunk, prompt_name, prompt, max_active_dims])
             last_chunk_id += 1
 
         output_queue = pool["output"]
@@ -601,7 +612,7 @@ class SparseEncoder(SentenceTransformer):
         """
         while True:
             try:
-                chunk_id, batch_size, sentences, prompt_name, prompt = input_queue.get()
+                chunk_id, batch_size, sentences, prompt_name, prompt, max_active_dims = input_queue.get()
                 embeddings = model.encode(
                     sentences,
                     prompt_name=prompt_name,
@@ -611,6 +622,7 @@ class SparseEncoder(SentenceTransformer):
                     batch_size=batch_size,
                     convert_to_sparse_tensor=True,
                     save_to_cpu=True,
+                    max_active_dims=max_active_dims,
                 )
 
                 results_queue.put([chunk_id, embeddings])
@@ -636,36 +648,10 @@ class SparseEncoder(SentenceTransformer):
 
     @contextmanager
     def truncate_sentence_embeddings(self, truncate_dim: int | None) -> Iterator[None]:
-        """
-        In this context, :meth:`SparseEncoder.encode <sentence_transformers.sparse_encoder.SparseEncoder.encode>` outputs
-        sentence embeddings with at most ``truncate_dim`` number of active dimensions.
-
-        This may be useful when you are using a model but want to have a treshold for the number of active dimensions
-        in the output to control the size of the embeddings you want to index.
-
-        Args:
-            truncate_dim (int, optional): The dimension to truncate sentence embeddings to. ``None`` does no truncation.
-
-        Example:
-            ::
-
-                from sentence_transformers import SparseEncoder
-
-                model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
-
-                with model.truncate_sentence_embeddings(truncate_dim=16):
-                    embeddings_truncated = model.encode(["hello there", "hiya"])
-
-                for i in range(embeddings_truncated.shape[0]):
-                    num_nonzero = embeddings_truncated[i].coalesce().indices().shape[1]
-                    assert num_nonzero <= 16, f"Embedding {i} has {num_nonzero} non-zero elements"
-        """
-        original_output_dim = self.truncate_dim
-        try:
-            self.truncate_dim = truncate_dim
-            yield
-        finally:
-            self.truncate_dim = original_output_dim
+        raise NotImplementedError(
+            "SparseEncoder does not support truncating sentence embeddings. "
+            "Use the `max_active_dims` parameter in the encode method instead."
+        )
 
     def save(
         self,

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -222,9 +222,9 @@ class SparseEncoder(SentenceTransformer):
                 of active dimensions and can be slow or memory-intensive if your model wasn't (yet) finetuned to high sparsity.
 
         Returns:
-            Union[List[Tensor], ndarray, Tensor]: By default, a 2d numpy array with shape [num_inputs, output_dimension] is returned.
-            If only one string input is provided, then the output is a 1d array with shape [output_dimension]. If ``convert_to_tensor``,
-            a torch Tensor is returned instead. If ``self.truncate_dim <= output_dimension`` then output_dimension is ``self.truncate_dim``.
+            Union[List[Tensor], ndarray, Tensor]: By default, a 2d torch sparse tensor with shape [num_inputs, output_dimension] is returned.
+            If only one string input is provided, then the output is a 1d array with shape [output_dimension]. If save_to_cpu is True,
+            the embeddings are moved to the CPU.
 
         Example:
             ::

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -57,8 +57,8 @@ class SparseEncoder(SentenceTransformer):
         local_files_only (bool, optional): Whether or not to only look at local files (i.e., do not try to download the model).
         token (bool or str, optional): Hugging Face authentication token to download private models.
         use_auth_token (bool or str, optional): Deprecated argument. Please use `token` instead.
-        max_active_dims (int, optional): The maximum number of active dimensions in the output of the model. Defaults to None. This mean there will be no
-            limit on the number of active dimensions and can be risky when indexing the embeddings.
+        max_active_dims (int, optional): The maximum number of active (non-zero) dimensions in the output of the model. Defaults to None. This means there will be no
+            limit on the number of active dimensions and can be slow or memory-intensive if your model wasn't (yet) finetuned to high sparsity.
         model_kwargs (Dict[str, Any], optional): Additional model configuration parameters to be passed to the Hugging Face Transformers model.
             Particularly useful options are:
 
@@ -217,8 +217,9 @@ class SparseEncoder(SentenceTransformer):
             save_to_cpu (bool, optional):  Whether the output should be moved to cpu or stay on the device it has been computed on.
                 Defaults to False
             device (str, optional): Which :class:`torch.device` to use for the computation, if None current device will be use. Defaults to None.
-            max_active_dims (int, optional): The maximum number of active dimensions in the output of the model. `None` means we will used the value of the
-                model's config. Defaults to None.
+            max_active_dims (int, optional): The maximum number of active (non-zero) dimensions in the output of the model. `None` means we will
+                used the value of the model's config. Defaults to None. If None in model's config it means there will be no limit on the number
+                of active dimensions and can be slow or memory-intensive if your model wasn't (yet) finetuned to high sparsity.
 
         Returns:
             Union[List[Tensor], ndarray, Tensor]: By default, a 2d numpy array with shape [num_inputs, output_dimension] is returned.
@@ -540,8 +541,9 @@ class SparseEncoder(SentenceTransformer):
             chunk_size (int): Sentences are chunked and sent to the individual processes. If None, it determines a
                 sensible size. Defaults to None.
             show_progress_bar (bool, optional): Whether to output a progress bar when encode sentences. Defaults to None.
-            max_active_dims (int, optional): The maximum number of active dimensions in the output of the model. `None` means we will used the value of the
-                model's config. Defaults to None.
+            max_active_dims (int, optional): The maximum number of active (non-zero) dimensions in the output of the model. `None` means we will
+                used the value of the model's config. Defaults to None. If None in model's config it means there will be no limit on the number
+                of active dimensions and can be slow or memory-intensive if your model wasn't (yet) finetuned to high sparsity.
 
         Returns:
             Tensor: A 2D tensor with shape [num_inputs, output_dimension].

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -168,7 +168,6 @@ class SparseEncoder(SentenceTransformer):
             local_files_only=local_files_only,
             token=token,
             use_auth_token=use_auth_token,
-            truncate_dim=None,
             model_kwargs=model_kwargs,
             tokenizer_kwargs=tokenizer_kwargs,
             config_kwargs=config_kwargs,

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -294,6 +294,8 @@ class SparseEncoder(SentenceTransformer):
         self.to(device)
 
         max_active_dims = max_active_dims if max_active_dims is not None else self.max_active_dims
+        if max_active_dims is not None:
+            kwargs["max_active_dims"] = max_active_dims
 
         all_embeddings = []
         length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -132,6 +132,8 @@ class SparseEncoder(SentenceTransformer):
             #         [0.11269, 0.019061, 29.612]])
     """
 
+    model_card_data_class = SparseEncoderModelCardData
+
     def __init__(
         self,
         model_name_or_path: str | None = None,
@@ -174,8 +176,6 @@ class SparseEncoder(SentenceTransformer):
             backend=backend,
         )
         self.max_active_dims = max_active_dims
-        self.model_card_data = model_card_data or SparseEncoderModelCardData()
-        self.model_card_data.register_model(self)
 
     def encode(
         self,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseBinaryClassificationEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseBinaryClassificationEvaluator.py
@@ -36,7 +36,7 @@ class SparseBinaryClassificationEvaluator(BinaryClassificationEvaluator):
         batch_size (int, optional): Batch size used to compute embeddings. Defaults to 32.
         show_progress_bar (bool, optional): If true, prints a progress bar. Defaults to False.
         write_csv (bool, optional): Write results to a CSV file. Defaults to True.
-        truncate_dim (Optional[int], optional): The dimension to truncate sentence embeddings to. `None` uses the model's current truncation dimension. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use. `None` uses the model's current `max_active_dims`. Defaults to None.
         similarity_fn_names (Optional[List[Literal["cosine", "dot", "euclidean", "manhattan"]]], optional): The similarity functions to use. If not specified, defaults to the ``similarity_fn_name`` attribute of the model. Defaults to None.
 
     Example:
@@ -112,9 +112,10 @@ class SparseBinaryClassificationEvaluator(BinaryClassificationEvaluator):
         batch_size: int = 32,
         show_progress_bar: bool = False,
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
         similarity_fn_names: list[Literal["cosine", "dot", "euclidean", "manhattan"]] | None = None,
     ):
+        self.max_active_dims = max_active_dims
         return super().__init__(
             sentences1=sentences1,
             sentences2=sentences2,
@@ -123,7 +124,7 @@ class SparseBinaryClassificationEvaluator(BinaryClassificationEvaluator):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             write_csv=write_csv,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
             similarity_fn_names=similarity_fn_names,
         )
 
@@ -141,13 +142,13 @@ class SparseBinaryClassificationEvaluator(BinaryClassificationEvaluator):
         sentences: str | list[str] | np.ndarray,
         **kwargs,
     ) -> Tensor:
-        kwargs["truncate_dim"] = self.truncate_dim
         return model.encode(
             sentences,
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_sparse_tensor=True,
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseBinaryClassificationEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseBinaryClassificationEvaluator.py
@@ -124,7 +124,6 @@ class SparseBinaryClassificationEvaluator(BinaryClassificationEvaluator):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             write_csv=write_csv,
-            truncate_dim=None,
             similarity_fn_names=similarity_fn_names,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseEmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseEmbeddingSimilarityEvaluator.py
@@ -37,8 +37,8 @@ class SparseEmbeddingSimilarityEvaluator(EmbeddingSimilarityEvaluator):
         name (str, optional): The name of the evaluator. Defaults to "".
         show_progress_bar (bool, optional): Whether to show a progress bar during evaluation. Defaults to False.
         write_csv (bool, optional): Whether to write the evaluation results to a CSV file. Defaults to True.
-        truncate_dim (Optional[int], optional): The dimension to truncate sentence embeddings to. `None` uses the
-            model's current truncation dimension. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
 
     Example:
         ::
@@ -89,8 +89,9 @@ class SparseEmbeddingSimilarityEvaluator(EmbeddingSimilarityEvaluator):
         name: str = "",
         show_progress_bar: bool = False,
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
     ):
+        self.max_active_dims = max_active_dims
         return super().__init__(
             sentences1=sentences1,
             sentences2=sentences2,
@@ -102,7 +103,7 @@ class SparseEmbeddingSimilarityEvaluator(EmbeddingSimilarityEvaluator):
             show_progress_bar=show_progress_bar,
             write_csv=write_csv,
             precision=None,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
         )
 
     def __call__(
@@ -116,13 +117,13 @@ class SparseEmbeddingSimilarityEvaluator(EmbeddingSimilarityEvaluator):
         sentences: str | list[str] | np.ndarray,
         **kwargs,
     ) -> Tensor:
-        kwargs["truncate_dim"] = self.truncate_dim
         return model.encode(
             sentences,
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_sparse_tensor=True,
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseEmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseEmbeddingSimilarityEvaluator.py
@@ -103,7 +103,6 @@ class SparseEmbeddingSimilarityEvaluator(EmbeddingSimilarityEvaluator):
             show_progress_bar=show_progress_bar,
             write_csv=write_csv,
             precision=None,
-            truncate_dim=None,
         )
 
     def __call__(

--- a/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
@@ -39,7 +39,8 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         batch_size (int): The batch size for evaluation. Defaults to 32.
         name (str): A name for the evaluation. Defaults to "".
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
-        truncate_dim (int, optional): The dimension to truncate the embeddings to. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
         score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to the ``similarity`` function from the ``model``.
         main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
         query_prompt (str, optional): The prompt to be used when encoding the corpus. Defaults to None.
@@ -143,7 +144,7 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         batch_size: int = 32,
         name: str = "",
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
         score_functions: dict[str, Callable[[Tensor, Tensor], Tensor]] | None = None,
         main_score_function: str | SimilarityFunction | None = None,
         query_prompt: str | None = None,
@@ -151,6 +152,7 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         corpus_prompt: str | None = None,
         corpus_prompt_name: str | None = None,
     ) -> None:
+        self.max_active_dims = max_active_dims
         return super().__init__(
             queries=queries,
             corpus=corpus,
@@ -165,7 +167,7 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
             batch_size=batch_size,
             name=name,
             write_csv=write_csv,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
             score_functions=score_functions,
             main_score_function=main_score_function,
             query_prompt=query_prompt,
@@ -204,6 +206,7 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
             show_progress_bar=self.show_progress_bar,
             convert_to_sparse_tensor=True,
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
         sparsity_infos = model.get_sparsity_stats(embeddings)

--- a/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
@@ -167,7 +167,6 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
             batch_size=batch_size,
             name=name,
             write_csv=write_csv,
-            truncate_dim=None,
             score_functions=score_functions,
             main_score_function=main_score_function,
             query_prompt=query_prompt,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
@@ -196,7 +196,6 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         prompt: str | None = None,
         **kwargs,
     ) -> Tensor:
-        kwargs["truncate_dim"] = self.truncate_dim
         embeddings = model.encode(
             sentences,
             prompt_name=prompt_name,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseMSEEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseMSEEvaluator.py
@@ -36,8 +36,8 @@ class SparseMSEEvaluator(MSEEvaluator):
         batch_size (int, optional): Batch size to compute sentence embeddings. Defaults to 32.
         name (str, optional): Name of the evaluator. Defaults to "".
         write_csv (bool, optional): Write results to CSV file. Defaults to True.
-        truncate_dim (int, optional): The dimension to truncate sentence embeddings to. `None` uses the model's current truncation
-            dimension. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
 
     Example:
         ::
@@ -87,8 +87,9 @@ class SparseMSEEvaluator(MSEEvaluator):
         batch_size: int = 32,
         name: str = "",
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
     ):
+        self.max_active_dims = max_active_dims
         super().__init__(
             source_sentences=source_sentences,
             target_sentences=target_sentences,
@@ -97,7 +98,7 @@ class SparseMSEEvaluator(MSEEvaluator):
             batch_size=batch_size,
             name=name,
             write_csv=write_csv,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
         )
         logger.warning(
             "The SparseMSEEvaluator is not handling the mse compute with sparse tensors yet. Memory issues may occur."
@@ -125,6 +126,7 @@ class SparseMSEEvaluator(MSEEvaluator):
             show_progress_bar=self.show_progress_bar,
             convert_to_sparse_tensor=False,
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseMSEEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseMSEEvaluator.py
@@ -98,7 +98,6 @@ class SparseMSEEvaluator(MSEEvaluator):
             batch_size=batch_size,
             name=name,
             write_csv=write_csv,
-            truncate_dim=None,
         )
         logger.warning(
             "The SparseMSEEvaluator is not handling the mse compute with sparse tensors yet. Memory issues may occur."

--- a/sentence_transformers/sparse_encoder/evaluation/SparseMSEEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseMSEEvaluator.py
@@ -118,7 +118,6 @@ class SparseMSEEvaluator(MSEEvaluator):
         sentences: str | list[str] | np.ndarray,
         **kwargs,
     ) -> Tensor:
-        kwargs["truncate_dim"] = self.truncate_dim
         return model.encode(
             sentences,
             batch_size=self.batch_size,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -191,5 +191,5 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
         self, dataset_name: DatasetNameType, **ir_evaluator_kwargs
     ) -> SparseInformationRetrievalEvaluator:
         ir_evaluator_kwargs["max_active_dims"] = self.max_active_dims
-        ir_evaluator_kwargs.pop("truncate_dim")
+        ir_evaluator_kwargs.pop("truncate_dim", None)
         return super()._load_dataset(dataset_name, **ir_evaluator_kwargs)

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -174,7 +174,6 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
             show_progress_bar=show_progress_bar,
             batch_size=batch_size,
             write_csv=write_csv,
-            truncate_dim=None,
             score_functions=score_functions,
             main_score_function=main_score_function,
             aggregate_fn=aggregate_fn,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -41,7 +41,8 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
         show_progress_bar (bool): Whether to show a progress bar during evaluation. Defaults to False.
         batch_size (int): The batch size for evaluation. Defaults to 32.
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
-        truncate_dim (int, optional): The dimension to truncate the embeddings to. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
         score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to {SimilarityFunction.COSINE.value: cos_sim, SimilarityFunction.DOT_PRODUCT.value: dot_score}.
         main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
         aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
@@ -154,7 +155,7 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
         show_progress_bar: bool = False,
         batch_size: int = 32,
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
         score_functions: dict[str, Callable[[Tensor, Tensor], Tensor]] = None,
         main_score_function: str | SimilarityFunction | None = None,
         aggregate_fn: Callable[[list[float]], float] = np.mean,
@@ -162,6 +163,7 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
         query_prompts: str | dict[str, str] | None = None,
         corpus_prompts: str | dict[str, str] | None = None,
     ):
+        self.max_active_dims = max_active_dims
         super().__init__(
             dataset_names=dataset_names,
             mrr_at_k=mrr_at_k,
@@ -172,7 +174,7 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
             show_progress_bar=show_progress_bar,
             batch_size=batch_size,
             write_csv=write_csv,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
             score_functions=score_functions,
             main_score_function=main_score_function,
             aggregate_fn=aggregate_fn,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -190,4 +190,6 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
     def _load_dataset(
         self, dataset_name: DatasetNameType, **ir_evaluator_kwargs
     ) -> SparseInformationRetrievalEvaluator:
+        ir_evaluator_kwargs["max_active_dims"] = self.max_active_dims
+        ir_evaluator_kwargs.pop("truncate_dim")
         return super()._load_dataset(dataset_name, **ir_evaluator_kwargs)

--- a/sentence_transformers/sparse_encoder/evaluation/SparseRerankingEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseRerankingEvaluator.py
@@ -124,7 +124,6 @@ class SparseRerankingEvaluator(RerankingEvaluator):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             use_batched_encoding=use_batched_encoding,
-            truncate_dim=None,
             mrr_at_k=mrr_at_k,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseRerankingEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseRerankingEvaluator.py
@@ -37,7 +37,8 @@ class SparseRerankingEvaluator(RerankingEvaluator):
         batch_size (int, optional): Batch size to compute sentence embeddings. Defaults to 64.
         show_progress_bar (bool, optional): Show progress bar when computing embeddings. Defaults to False.
         use_batched_encoding (bool, optional): Whether or not to encode queries and documents in batches for greater speed, or 1-by-1 to save memory. Defaults to True.
-        truncate_dim (Optional[int], optional): The dimension to truncate sentence embeddings to. `None` uses the model's current truncation dimension. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
         mrr_at_k (Optional[int], optional): Deprecated parameter. Please use `at_k` instead. Defaults to None.
 
     Example:
@@ -110,9 +111,10 @@ class SparseRerankingEvaluator(RerankingEvaluator):
         batch_size: int = 64,
         show_progress_bar: bool = False,
         use_batched_encoding: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
         mrr_at_k: int | None = None,
     ):
+        self.max_active_dims = max_active_dims
         return super().__init__(
             samples=samples,
             at_k=at_k,
@@ -122,7 +124,7 @@ class SparseRerankingEvaluator(RerankingEvaluator):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             use_batched_encoding=use_batched_encoding,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
             mrr_at_k=mrr_at_k,
         )
 
@@ -155,6 +157,7 @@ class SparseRerankingEvaluator(RerankingEvaluator):
             convert_to_sparse_tensor=True,
             convert_to_tensor=False,  # as we are using slicing on sparse tensors that is not supported so we want to keep a list of sparse tensors
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseRerankingEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseRerankingEvaluator.py
@@ -148,7 +148,6 @@ class SparseRerankingEvaluator(RerankingEvaluator):
         show_progress_bar: bool | None = None,
         **kwargs,
     ) -> Tensor:
-        kwargs["truncate_dim"] = self.truncate_dim
         return model.encode(
             sentences,
             batch_size=self.batch_size,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseTranslationEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseTranslationEvaluator.py
@@ -33,8 +33,8 @@ class SparseTranslationEvaluator(TranslationEvaluator):
         name (str): The name of the evaluator. Defaults to an empty string.
         print_wrong_matches (bool): Whether to print incorrect matches. Defaults to False.
         write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
-        truncate_dim (int, optional): The dimension to truncate sentence embeddings to. If None, the model's
-            current truncation dimension will be used. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
 
     Example:
         ::
@@ -83,8 +83,9 @@ class SparseTranslationEvaluator(TranslationEvaluator):
         name: str = "",
         print_wrong_matches: bool = False,
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
     ):
+        self.max_active_dims = max_active_dims
         return super().__init__(
             source_sentences,
             target_sentences,
@@ -93,7 +94,7 @@ class SparseTranslationEvaluator(TranslationEvaluator):
             name=name,
             print_wrong_matches=print_wrong_matches,
             write_csv=write_csv,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
         )
 
     def __call__(
@@ -107,7 +108,6 @@ class SparseTranslationEvaluator(TranslationEvaluator):
         sentences: str | list[str] | np.ndarray,
         **kwargs,
     ) -> list[Tensor]:
-        kwargs["truncate_dim"] = self.truncate_dim
         return model.encode(
             sentences,
             batch_size=self.batch_size,
@@ -115,6 +115,7 @@ class SparseTranslationEvaluator(TranslationEvaluator):
             convert_to_tensor=False,
             convert_to_sparse_tensor=True,
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseTranslationEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseTranslationEvaluator.py
@@ -94,7 +94,6 @@ class SparseTranslationEvaluator(TranslationEvaluator):
             name=name,
             print_wrong_matches=print_wrong_matches,
             write_csv=write_csv,
-            truncate_dim=None,
         )
 
     def __call__(

--- a/sentence_transformers/sparse_encoder/evaluation/SparseTripletEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseTripletEvaluator.py
@@ -39,8 +39,8 @@ class SparseTripletEvaluator(TripletEvaluator):
         batch_size (int): Batch size used to compute embeddings. Defaults to 16.
         show_progress_bar (bool): If true, prints a progress bar. Defaults to False.
         write_csv (bool): Write results to a CSV file. Defaults to True.
-        truncate_dim (int, optional): The dimension to truncate sentence embeddings to.
-            `None` uses the model's current truncation dimension. Defaults to None.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
         similarity_fn_names (List[str], optional): List of similarity function names to evaluate.
             If not specified, evaluate using the ``model.similarity_fn_name``.
             Defaults to None.
@@ -99,10 +99,11 @@ class SparseTripletEvaluator(TripletEvaluator):
         batch_size: int = 16,
         show_progress_bar: bool = False,
         write_csv: bool = True,
-        truncate_dim: int | None = None,
+        max_active_dims: int | None = None,
         similarity_fn_names: list[Literal["cosine", "dot", "euclidean", "manhattan"]] | None = None,
         main_distance_function: str | SimilarityFunction | None = "deprecated",
     ):
+        self.max_active_dims = max_active_dims
         return super().__init__(
             anchors=anchors,
             positives=positives,
@@ -113,7 +114,7 @@ class SparseTripletEvaluator(TripletEvaluator):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             write_csv=write_csv,
-            truncate_dim=truncate_dim,
+            truncate_dim=None,
             similarity_fn_names=similarity_fn_names,
             main_distance_function=main_distance_function,
         )
@@ -129,13 +130,13 @@ class SparseTripletEvaluator(TripletEvaluator):
         sentences: str | list[str] | np.ndarray,
         **kwargs,
     ) -> Tensor:
-        kwargs["truncate_dim"] = self.truncate_dim
         return model.encode(
             sentences,
             batch_size=self.batch_size,
             show_progress_bar=self.show_progress_bar,
             convert_to_sparse_tensor=True,
             save_to_cpu=True,
+            max_active_dims=self.max_active_dims,
             **kwargs,
         )
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseTripletEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseTripletEvaluator.py
@@ -114,7 +114,6 @@ class SparseTripletEvaluator(TripletEvaluator):
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             write_csv=write_csv,
-            truncate_dim=None,
             similarity_fn_names=similarity_fn_names,
             main_distance_function=main_distance_function,
         )

--- a/sentence_transformers/sparse_encoder/models/CSRSparsity.py
+++ b/sentence_transformers/sparse_encoder/models/CSRSparsity.py
@@ -52,7 +52,7 @@ class CSRSparsity(Module):
 
     config_keys = ["input_dim", "hidden_dim", "k", "k_aux", "normalize", "dead_threshold"]
 
-    forward_kwargs = {"truncate_dim"}
+    forward_kwargs = {"max_active_dims"}
 
     def __init__(
         self,
@@ -154,8 +154,8 @@ class CSRSparsity(Module):
             ret = ret * info["std"] + info["mu"]
         return ret
 
-    def forward(self, features: torch.Tensor, truncate_dim: int | None = None) -> torch.Tensor:
-        k = truncate_dim if truncate_dim is not None else self.k
+    def forward(self, features: torch.Tensor, max_active_dims: int | None = None) -> torch.Tensor:
+        k = max_active_dims if max_active_dims is not None else self.k
         x = features["sentence_embedding"]
 
         x, info = self.preprocess(x)


### PR DESCRIPTION
Replace truncate_dim with max_active_dims across evaluators and SparseEncoder. Removed truncate context manager; updated utilities for compatibility.