### PR TITLE
Add model initialization details to training overview for ST

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -29,19 +29,21 @@ dl.class > dt {
 .components {
     display: flex;
     flex-flow: row wrap;
+    gap: 1rem; /* Use gap for consistent spacing */
 }
 
 .components > .box {
-    flex: 1;
-    margin: 0.5rem;
+    flex: 0 0 auto; /* Don't grow or shrink, use natural size */
+    margin: 0; /* Remove margin since we're using gap */
     padding: 1rem;
     border-style: solid;
     border-width: 1px;
     border-radius: 0.5rem;
     border-color: rgb(55 65 81);
     background-color: #e3e3e3;
-    color: #404040; /* Override the colors imposed by <a href> */
-    max-width: 18rem;
+    color: #404040;
+    width: 11.3rem;
+    box-sizing: border-box;
 }
 
 .components > .box:nth-child(1) > .header {
@@ -63,6 +65,11 @@ dl.class > dt {
 .components > .box:nth-child(5) > .header {
     background-image: linear-gradient(to bottom right, #34d399, #10b981);
 }
+
+.components > .box:nth-child(6) > .header {
+    background-image: linear-gradient(to bottom right, #fbbf24, #f59e0b);
+}
+
 
 .components > .optional {
     background: repeating-linear-gradient(

--- a/docs/cross_encoder/training_overview.md
+++ b/docs/cross_encoder/training_overview.md
@@ -67,6 +67,8 @@ Cross Encoder models are initialized by loading a pretrained `transformers <http
     - `sentence similarity models <https://huggingface.co/models?pipeline_tag=sentence-similarity>`_ - trained for text embeddings
     - `feature-extraction models <https://huggingface.co/models?pipeline_tag=feature-extraction>`_ - trained for text embeddings
 
+    Consider looking for base models that are designed on your language and/or domain of interest. For example, `klue/bert-base <https://huggingface.co/klue/bert-base>`_ will work much better than `google-bert/bert-base-uncased <https://huggingface.co/google-bert/bert-base-uncased>`_ for Korean.
+
 ```
 
 ## Dataset

--- a/docs/cross_encoder/training_overview.md
+++ b/docs/cross_encoder/training_overview.md
@@ -9,9 +9,13 @@ See [**Training Examples**](training/examples) for numerous training scripts for
 
 
 ## Training Components
-Training Cross Encoder models involves between 3 to 5 components, just like [training Sentence Transformer models](../sentence_transformer/training_overview.md):
+Training Cross Encoder models involves between 4 to 6 components, just like [training Sentence Transformer models](../sentence_transformer/training_overview.md):
 
 <div class="components">
+    <a href="#model" class="box">
+        <div class="header">Model</div>
+        Learn how to initialize the <b>model</b> for training.
+    </a>
     <a href="#dataset" class="box">
         <div class="header">Dataset</div>
         Learn how to prepare the <b>data</b> for training.
@@ -34,6 +38,36 @@ Training Cross Encoder models involves between 3 to 5 components, just like [tra
     </a>
 </div>
 <p></p>
+
+## Model
+```{eval-rst}
+
+Cross Encoder models are initialized by loading a pretrained `transformers <https://huggingface.co/docs/transformers>`_ model using a sequence classification head. If the model itself does not have such a head, then it will be added automatically. Consequently, initializing a Cross Encoder model is rather simple:
+
+.. sidebar:: Documentation
+
+    - :class:`sentence_transformers.cross_encoder.CrossEncoder`
+
+::
+
+    from sentence_transformers import CrossEncoder
+
+    # This model already has a sequence classification head
+    model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2")
+    # And this model does not, so it will be added automatically
+    model = CrossEncoder("google-bert/bert-base-uncased")
+
+.. tip::
+
+    You can find pretrained reranker models in the `Cross Encoder > Pretrained Models <pretrained_models.html>`_ documentation.
+
+    For other models, the strongest pretrained models are often "encoder models", i.e. models that are trained to produce a meaningful token embedding for inputs. You can find strong candidates here:
+
+    - `fill-mask models <https://huggingface.co/models?pipeline_tag=fill-mask>`_ - trained for token embeddings
+    - `sentence similarity models <https://huggingface.co/models?pipeline_tag=sentence-similarity>`_ - trained for text embeddings
+    - `feature-extraction models <https://huggingface.co/models?pipeline_tag=feature-extraction>`_ - trained for text embeddings
+
+```
 
 ## Dataset
 ```{eval-rst}

--- a/docs/sentence_transformer/training_overview.md
+++ b/docs/sentence_transformer/training_overview.md
@@ -15,7 +15,7 @@ Also see [**Training Examples**](training/examples) for numerous training script
 
 
 ## Training Components
-Training Sentence Transformer models involves between 3 to 5 components:
+Training Sentence Transformer models involves between 4 to 6 components:
 
 <div class="components">
     <a href="#model" class="box">

--- a/docs/sentence_transformer/training_overview.md
+++ b/docs/sentence_transformer/training_overview.md
@@ -18,6 +18,10 @@ Also see [**Training Examples**](training/examples) for numerous training script
 Training Sentence Transformer models involves between 3 to 5 components:
 
 <div class="components">
+    <a href="#model" class="box">
+        <div class="header">Model</div>
+        Learn how to initialize the <b>model</b> for training.
+    </a>
     <a href="#dataset" class="box">
         <div class="header">Dataset</div>
         Learn how to prepare the <b>data</b> for training.
@@ -41,6 +45,86 @@ Training Sentence Transformer models involves between 3 to 5 components:
 </div>
 <p></p>
 
+## Model
+```{eval-rst}
+
+Sentence Transformer models consist of a sequence of `Modules <../package_reference/sentence_transformer/models.html>`_ or `Custom Modules <usage/custom_models.html#advanced-custom-modules>`_, allowing for a lot of flexibility. If you want to further finetune a SentenceTransformer model (e.g. it has a `modules.json file <https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/main/modules.json>`_), then you don't have to worry about which modules are used::
+
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+
+But if instead you want to train from another checkpoint, or from scratch, then these are the most common architectures you can use:
+
+.. tab:: Transformers
+
+    Most Sentence Transformer models use the :class:`~sentence_transformers.models.Transformer` and :class:`~sentence_transformers.models.Pooling` modules. The former loads a pretrained transformer model (e.g. `BERT <https://huggingface.co/google-bert/bert-base-uncased>`_, `RoBERTa <https://huggingface.co/FacebookAI/roberta-base>`_, `DistilBERT <https://huggingface.co/distilbert/distilbert-base-uncased>`_, `ModernBERT <https://huggingface.co/answerdotai/ModernBERT-base>`_, etc.) and the latter pools the output of the transformer to produce a single vector representation for each input sentence.
+
+    .. raw:: html
+
+        <div class="sidebar">
+            <p class="sidebar-title">Documentation</p>
+            <ul class="simple">
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.Transformer"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.models.Transformer</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.Pooling"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.models.Pooling</span></code></a></li>
+            </ul>
+        </div>
+
+    ::
+
+        from sentence_transformers import models, SentenceTransformer
+
+        transformer = models.Transformer("google-bert/bert-base-uncased")
+        pooling = models.Pooling(transformer.get_word_embedding_dimension(), pooling_mode="mean")
+
+        model = SentenceTransformer(modules=[transformer, pooling])
+    
+    This is the default option in Sentence Transformers, so it's easier to use the shortcut:
+
+    ::
+
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer("google-bert/bert-base-uncased")
+
+    .. tip::
+
+        The strongest base models are often "encoder models", i.e. models that are trained to produce a meaningful token embedding for inputs. You can find strong candidates here:
+
+        - `fill-mask models <https://huggingface.co/models?pipeline_tag=fill-mask>`_ - trained for token embeddings
+        - `sentence similarity models <https://huggingface.co/models?pipeline_tag=sentence-similarity>`_ - trained for text embeddings
+        - `feature-extraction models <https://huggingface.co/models?pipeline_tag=feature-extraction>`_ - trained for text embeddings
+
+.. tab:: Static
+
+    Static Embedding models (`blogpost <https://huggingface.co/blog/static-embeddings>`_) use the :class:`~sentence_transformers.models.StaticEmbedding` module, and are encoder models that don't use slow transformers or attention mechanisms. For these models, computing embeddings is simply: given the input token, return the pre-computed token embedding. These models are orders of magnitude faster, but cannot capture complex semantics as token embeddings are computed separate from the context.
+
+    .. raw:: html
+
+        <div class="sidebar">
+            <p class="sidebar-title">Documentation</p>
+            <ul class="simple">
+                <li><a class="reference external" href="https://huggingface.co/blog/static-embeddings">Static Embedding Models</a></li>
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.StaticEmbedding"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.models.StaticEmbedding</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.StaticEmbedding.from_model2vec"><code class="xref py py-meth docutils literal notranslate"><span class="pre">sentence_transformers.models.StaticEmbedding.from_model2vec</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.StaticEmbedding.from_distillation"><code class="xref py py-meth docutils literal notranslate"><span class="pre">sentence_transformers.models.StaticEmbedding.from_distillation</span></code></a></li>
+            </ul>
+        </div>
+
+    ::
+
+        from sentence_transformers import models, SentenceTransformer
+        from tokenizers import Tokenizer
+
+        # Load any Tokenizer from Hugging Face
+        tokenizer = Tokenizer.from_pretrained("google-bert/bert-base-uncased")
+        # The `embedding_dim` is the dimensionality (size) of the token embeddings
+        static_embedding = StaticEmbedding(tokenizer, embedding_dim=512)
+
+        model = SentenceTransformer(modules=[static_embedding])
+
+```
+
 ## Dataset
 ```{eval-rst}
 The :class:`SentenceTransformerTrainer` trains and evaluates using :class:`datasets.Dataset` (one dataset) or :class:`datasets.DatasetDict` instances (multiple datasets, see also `Multi-dataset training <#multi-dataset-training>`_). 
@@ -55,7 +139,7 @@ The :class:`SentenceTransformerTrainer` trains and evaluates using :class:`datas
             <p class="sidebar-title">Documentation</p>
             <ul class="simple">
                 <li><a class="reference external" href="https://huggingface.co/docs/datasets/main/en/loading#hugging-face-hub">Datasets, Loading from the Hugging Face Hub</a></li>
-                <li><a class="reference external" href="https://huggingface.co/docs/datasets/main/en/package_reference/loading_methods#datasets.load_dataset" title="(in datasets vmain)"><code class="xref py py-func docutils literal notranslate"><span class="pre">datasets.load_dataset()</span></code></a></li>
+                <li><a class="reference external" href="https://huggingface.co/docs/datasets/main/en/package_reference/loading_methods#datasets.load_dataset"><code class="xref py py-func docutils literal notranslate"><span class="pre">datasets.load_dataset()</span></code></a></li>
                 <li><a class="reference external" href="https://huggingface.co/datasets/sentence-transformers/all-nli">sentence-transformers/all-nli</a></li>
             </ul>
         </div>

--- a/docs/sentence_transformer/training_overview.md
+++ b/docs/sentence_transformer/training_overview.md
@@ -95,6 +95,8 @@ But if instead you want to train from another checkpoint, or from scratch, then 
         - `sentence similarity models <https://huggingface.co/models?pipeline_tag=sentence-similarity>`_ - trained for text embeddings
         - `feature-extraction models <https://huggingface.co/models?pipeline_tag=feature-extraction>`_ - trained for text embeddings
 
+        Consider looking for base models that are designed on your language and/or domain of interest. For example, `FacebookAI/xlm-roberta-base <https://huggingface.co/FacebookAI/xlm-roberta-base>`_ will work better than `google-bert/bert-base-uncased <https://huggingface.co/google-bert/bert-base-uncased>`_ for Turkish.
+
 .. tab:: Static
 
     Static Embedding models (`blogpost <https://huggingface.co/blog/static-embeddings>`_) use the :class:`~sentence_transformers.models.StaticEmbedding` module, and are encoder models that don't use slow transformers or attention mechanisms. For these models, computing embeddings is simply: given the input token, return the pre-computed token embedding. These models are orders of magnitude faster, but cannot capture complex semantics as token embeddings are computed separate from the context.

--- a/docs/sparse_encoder/training_overview.md
+++ b/docs/sparse_encoder/training_overview.md
@@ -48,11 +48,11 @@ Training Sparse Encoder models involves between 4 to 6 components:
 ## Model
 ```{eval-rst}
 
-Sparse Encoder models consist of a sequence of `Modules <../package_reference/sentence_transformer/models.html>`_,  `Sparse Encoder specific ones <../package_reference/sparse_encoder/models.html>`_ or `Custom Modules <usage/custom_models.html#advanced-custom-modules>`_, allowing for a lot of flexibility. If you want to further finetune a SparseEncoder model (e.g. it has a `modules.json file <https://https://huggingface.co/naver/splade-cocondenser-ensembledistil/tree/main/modules.json>`_), then you don't have to worry about which modules are used::
+Sparse Encoder models consist of a sequence of `Modules <../package_reference/sentence_transformer/models.html>`_,  `Sparse Encoder specific ones <../package_reference/sparse_encoder/models.html>`_ or `Custom Modules <../sentence_transformer/usage/custom_models.html#advanced-custom-modules>`_, allowing for a lot of flexibility. If you want to further finetune a SparseEncoder model (e.g. it has a `modules.json file <https://huggingface.co/naver/splade-cocondenser-ensembledistil/tree/main/modules.json>`_), then you don't have to worry about which modules are used::
 
     from sentence_transformers import SparseEncoder
 
-    model = SentenceTransformer("naver/splade-cocondenser-ensembledistil")
+    model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
 
 But if instead you want to train from another checkpoint, or from scratch, then these are the most common architectures you can use:
 

--- a/docs/sparse_encoder/training_overview.md
+++ b/docs/sparse_encoder/training_overview.md
@@ -15,9 +15,13 @@ Also see [**Training Examples**](training/examples) for numerous training script
 
 
 ## Training Components
-Training Sparse Encoder models involves between 3 to 5 components just like [training Sentence Transformer models](../sentence_transformer/training_overview.md):
+Training Sparse Encoder models involves between 4 to 6 components:
 
 <div class="components">
+    <a href="#model" class="box">
+        <div class="header">Model</div>
+        Learn how to initialize the <b>model</b> for training.
+    </a>
     <a href="#dataset" class="box">
         <div class="header">Dataset</div>
         Learn how to prepare the <b>data</b> for training.
@@ -40,6 +44,153 @@ Training Sparse Encoder models involves between 3 to 5 components just like [tra
     </a>
 </div>
 <p></p>
+
+## Model
+```{eval-rst}
+
+Sparse Encoder models consist of a sequence of `Modules <../package_reference/sentence_transformer/models.html>`_,  `Sparse Encoder specific ones <../package_reference/sparse_encoder/models.html>`_ or `Custom Modules <usage/custom_models.html#advanced-custom-modules>`_, allowing for a lot of flexibility. If you want to further finetune a SparseEncoder model (e.g. it has a `modules.json file <https://https://huggingface.co/naver/splade-cocondenser-ensembledistil/tree/main/modules.json>`_), then you don't have to worry about which modules are used::
+
+    from sentence_transformers import SparseEncoder
+
+    model = SentenceTransformer("naver/splade-cocondenser-ensembledistil")
+
+But if instead you want to train from another checkpoint, or from scratch, then these are the most common architectures you can use:
+
+.. tab:: Splade
+
+    Splade models use the :class:`~sentence_transformers.sparse_encoder.models.MLMTransformer` followed by a :class:`~sentence_transformers.sparse_encoder.models.SpladePooling` modules. The former loads a pretrained Masked Language Model transformer model (e.g. `BERT <https://huggingface.co/google-bert/bert-base-uncased>`_, `RoBERTa <https://huggingface.co/FacebookAI/roberta-base>`_, `DistilBERT <https://huggingface.co/distilbert/distilbert-base-uncased>`_, `ModernBERT <https://huggingface.co/answerdotai/ModernBERT-base>`_, etc.) and the latter pools the output of the MLMHead to produce a single vector representation of the size of the vocabularies.
+    
+    .. raw:: html
+
+        <div class="sidebar">
+            <p class="sidebar-title">Documentation</p>
+            <ul class="simple">
+                <li><a class="reference internal" href="../package_reference/sparse_encoder/models.html#sentence_transformers.sparse_encoder.models.MLMTransformer"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.sparse_encoder.models.MLMTransformer</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sparse_encoder/models.html#sentence_transformers.sparse_encoder.models.SpladePooling"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.sparse_encoder.models.SpladePooling</span></code></a></li>
+            </ul>
+        </div>
+
+    ::
+
+        from sentence_transformers import models, SparseEncoder
+        from sentence_transformers.sparse_encoder.models import MLMTransformer, SpladePooling
+
+        # Initialize MLM Transformer (use a fill-mask model)
+        mlm_transformer = MLMTransformer("google-bert/bert-base-uncased")
+        
+        # Initialize SpladePooling module
+        splade_pooling = SpladePooling(pooling_strategy="max")
+
+        # Create the Splade model
+        model = SparseEncoder(modules=[mlm_transformer, splade_pooling])
+    
+    This architecture is the default if you provide a fill-mask model architecture to SparseEncoder, so it's easier to use the shortcut:.
+
+    ::
+
+        from sentence_transformers import SparseEncoder
+
+        model = SparseEncoder("google-bert/bert-base-uncased")
+
+
+.. tab:: Contrastive Sparse Representation (CSR) 
+
+    Contrastive Sparse Representation (CSR) models use a sequence of :class:`~sentence_transformers.models.Transformer`, :class:`~sentence_transformers.models.Pooling` and :class:`~sentence_transformers.sparse_encoder.models.CSRSparsity` modules to create sparse representations on top of an already trained encoder with Sentence Transfortmer.
+
+    .. raw:: html
+
+        <div class="sidebar">
+            <p class="sidebar-title">Documentation</p>
+            <ul class="simple">
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.Transformer"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.models.Transformer</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.Pooling"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.models.Pooling</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sparse_encoder/models.html#sentence_transformers.sparse_encoder.models.CSRSparsity"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.sparse_encoder.models.CSRSparsity</span></code></a></li>
+            </ul>
+        </div>
+
+    ::
+
+        from sentence_transformers import models, SparseEncoder
+        from sentence_transformers.sparse_encoder.models import CSRSparsity
+
+        # Initialize transformer (can be any dense encoder model)
+        transformer = models.Transformer("google-bert/bert-base-uncased")
+        
+        # Initialize pooling
+        pooling = models.Pooling(transformer.get_word_embedding_dimension(), pooling_mode="mean")
+        
+        # Initialize CSRSparsity module
+        csr_sparsity = CSRSparsity(
+            input_dim=transformer.get_word_embedding_dimension(),
+            hidden_dim=4 * transformer.get_word_embedding_dimension(),
+            k=256,  # Number of top values to keep
+            k_aux=512,  # Number of top values for auxiliary loss
+        )
+        # Create the CSR model
+        model = SparseEncoder(modules=[transformer, pooling, csr_sparsity])
+    
+    If a Transformer model is passed, it will automatically be loaded and a mean pooling and a CSRSparsity module will be added. As well for a Sentence Transformer, it will auto-loaded it and then add a default CSRSparsity on top of it, so it's easier to use the shortcut:
+
+    ::
+
+        from sentence_transformers import SparseEncoder
+
+        model = SparseEncoder("nvidia/NV-Embed-v2")
+
+    
+    .. tip::
+
+        CSR Sparsity can work on top of any dense encoder models but probably more useful fo the ones with high dimension representation like 4096 to try to improve the efficiency of the representation. 
+
+.. tab:: Splade Inference-free
+
+    Splade Inference-free uses an :class:`~sentence_transformers.models.Asym` module with different modules for queries and documents. Usually for this type of architecture, the documents part is a traditional splade architecture (with a :class:`~sentence_transformers.sparse_encoder.models.MLMTransformer` followed by a :class:`~sentence_transformers.sparse_encoder.models.SpladePooling` modules) and the query one is an :class:`~sentence_transformers.sparse_encoder.models.IDF` modules.
+
+    .. raw:: html
+
+        <div class="sidebar">
+            <p class="sidebar-title">Documentation</p>
+            <ul class="simple">
+                <li><a class="reference internal" href="../package_reference/sentence_transformer/models.html#sentence_transformers.models.Asym"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.models.Asym</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sparse_encoder/models.html#sentence_transformers.sparse_encoder.models.IDF"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.sparse_encoder.models.IDF</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sparse_encoder/models.html#sentence_transformers.sparse_encoder.models.MLMTransformer"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.sparse_encoder.models.MLMTransformer</span></code></a></li>
+                <li><a class="reference internal" href="../package_reference/sparse_encoder/models.html#sentence_transformers.sparse_encoder.models.SpladePooling"><code class="xref py py-class docutils literal notranslate"><span class="pre">sentence_transformers.sparse_encoder.models.SpladePooling</span></code></a></li>
+            </ul>
+        </div>
+
+    ::
+
+        from sentence_transformers import models, SparseEncoder
+        from sentence_transformers.sparse_encoder.models import IDF, MLMTransformer, SpladePooling
+
+        # Initialize MLM Transformer for document encoding
+        doc_encoder = MLMTransformer("google-bert/bert-base-uncased")
+
+        # Create an asymmetric model with different paths for queries and documents
+        asym = models.Asym(
+            {
+                "query": [IDF(tokenizer=doc_encoder.tokenizer, frozen=False)],
+                "doc": [
+                    # Document path: full MLM transformer + pooling
+                    doc_encoder,
+                    SpladePooling("max"),
+                ],
+            }
+        )
+
+        # Create the inference-free model
+        model = SparseEncoder(
+            modules=[asym],
+            similarity_fn_name="dot",
+        )
+
+    
+    This architecture allows for fast query-time processing using the lightweight IDF approach, that can be trained and seen as a linear weights, while documents are processed with the full MLM transformer and SpladePooling.
+
+    .. tip::
+
+        Splade Inference-free is particularly useful for search applications where query latency is critical, as it shifts the computational complexity to the document indexing phase.
+```
 
 ## Dataset
 ```{eval-rst}
@@ -545,7 +696,7 @@ The top performing models are trained using many datasets at once. Normally, thi
 
 Each training/evaluation batch will only contain samples from one of the datasets. The order in which batches are samples from the multiple datasets is defined by the :class:`~sentence_transformers.training_args.MultiDatasetBatchSamplers` enum, which can be passed to the :class:`~sentence_transformers.sparse_encoder.training_args.SparseEncoderTrainingArguments` via ``multi_dataset_batch_sampler``. Valid options are:
 
-- ``MultiDatasetBatchSamplers.ROUND_ROBIN``: Round-robin sampling from each dataset until one is exhausted. With this strategy, it’s likely that not all samples from each dataset are used, but each dataset is sampled from equally.
+- ``MultiDatasetBatchSamplers.ROUND_ROBIN``: Round-robin sampling from each dataset until one is exhausted. With this strategy, it's likely that not all samples from each dataset are used, but each dataset is sampled from equally.
 - ``MultiDatasetBatchSamplers.PROPORTIONAL`` (default): Sample from each dataset in proportion to its size. With this strategy, all samples from each dataset are used and larger datasets are sampled from more frequently.
 ```
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -302,15 +302,15 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                 if "/" not in model_name_or_path and model_name_or_path.lower() not in basic_transformer_models:
                     # A model from sentence-transformers
                     model_name_or_path = __MODEL_HUB_ORGANIZATION__ + "/" + model_name_or_path
-
+            has_modules = is_sentence_transformer_model(
+                model_name_or_path,
+                token,
+                cache_folder=cache_folder,
+                revision=revision,
+                local_files_only=local_files_only,
+            )
             if (
-                is_sentence_transformer_model(
-                    model_name_or_path,
-                    token,
-                    cache_folder=cache_folder,
-                    revision=revision,
-                    local_files_only=local_files_only,
-                )
+                has_modules
                 and self._get_model_type(
                     model_name_or_path,
                     token,
@@ -342,6 +342,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                     model_kwargs=model_kwargs,
                     tokenizer_kwargs=tokenizer_kwargs,
                     config_kwargs=config_kwargs,
+                    has_modules=has_modules,
                 )
 
         if modules is not None and not isinstance(modules, OrderedDict):
@@ -1633,6 +1634,7 @@ print(similarities)
         model_kwargs: dict[str, Any] | None = None,
         tokenizer_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
+        has_modules: bool = False,
     ) -> list[nn.Module]:
         """
         Creates a simple Transformer + Mean Pooling model and returns the modules
@@ -1647,6 +1649,7 @@ print(similarities)
             model_kwargs (Optional[Dict[str, Any]], optional): Additional keyword arguments for the model. Defaults to None.
             tokenizer_kwargs (Optional[Dict[str, Any]], optional): Additional keyword arguments for the tokenizer. Defaults to None.
             config_kwargs (Optional[Dict[str, Any]], optional): Additional keyword arguments for the config. Defaults to None.
+            has_modules (bool, optional): Whether the model has modules.json. Defaults to False.
 
         Returns:
             List[nn.Module]: A list containing the transformer model and the pooling model.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add model initialization details to training overview for ST and CE
* Update CSS such that we can fit 6 components in our components class

## Details
In short, it:
1. Explain how ST models are structured
2. Explain that you can just use `SentenceTransformer("...")` for ST models
3. Tabs for Transformer and Static with how they're initialized.
4. For Transformer, include a tip of what base models might work nicely.

Let me know what you think of the setup. 

- Tom Aarsen