### PR TITLE
Add Seismic semantic search example + docs

### DIFF
--- a/docs/package_reference/sparse_encoder/search_engines.md
+++ b/docs/package_reference/sparse_encoder/search_engines.md
@@ -4,5 +4,5 @@
 
 ```{eval-rst}
 .. automodule:: sentence_transformers.sparse_encoder.search_engines
-   :members: semantic_search_qdrant, semantic_search_elasticsearch
+   :members: semantic_search_qdrant, semantic_search_elasticsearch, semantic_search_seismic
 ```

--- a/examples/sparse_encoder/applications/semantic_search/semantic_search_elasticsearch.py
+++ b/examples/sparse_encoder/applications/semantic_search/semantic_search_elasticsearch.py
@@ -29,17 +29,17 @@ queries = dataset["query"][:2]
 # 3. Load the model
 sparse_model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
 
-# 5. Encode the corpus
+# 4. Encode the corpus
 corpus_embeddings = sparse_model.encode(corpus, convert_to_sparse_tensor=True, batch_size=32, show_progress_bar=True)
 
 corpus_index = None
 while True:
-    # 6. Encode the queries using the full precision
+    # 5. Encode the queries using the full precision
     start_time = time.time()
     query_embeddings = sparse_model.encode(queries, convert_to_sparse_tensor=True)
     print(f"Encoding time: {time.time() - start_time:.6f} seconds")
 
-    # 7. Perform semantic search using qdrant
+    # 6. Perform semantic search using Elasticsearch
     results, search_time, corpus_index = semantic_search_elasticsearch(
         query_embeddings,
         corpus_index=corpus_index,
@@ -48,7 +48,7 @@ while True:
         output_index=True,
     )
 
-    # 8. Output the results
+    # 7. Output the results
     print(f"Search time: {search_time:.6f} seconds")
     for query, result in zip(queries, results):
         print(f"Query: {query}")
@@ -56,5 +56,5 @@ while True:
             print(f"(Score: {entry['score']:.4f}) {corpus[entry['corpus_id']]}, corpus_id: {entry['corpus_id']}")
         print("")
 
-    # 10. Prompt for more queries
+    # 8. Prompt for more queries
     queries = [input("Please enter a question: ")]

--- a/examples/sparse_encoder/applications/semantic_search/semantic_search_seismic.py
+++ b/examples/sparse_encoder/applications/semantic_search/semantic_search_seismic.py
@@ -1,14 +1,10 @@
 """
-This script contains an example how to perform semantic search with Qdrant.
+This script contains an example how to perform semantic search with Seismic.
 
-You need Qdrant up and running locally:
-https://qdrant.tech/documentation/quickstart/
-
-Further, you need the Python Qdrant Client installed: https://python-client.qdrant.tech/, e.g.:
+All you need is installing the `pyseismic-lsr` package:
 ```
-pip install qdrant-client
+pip install pyseismic-lsr
 ```
-This script was created for `qdrant-client` v1.0+.
 """
 
 import time
@@ -16,7 +12,7 @@ import time
 from datasets import load_dataset
 
 from sentence_transformers import SparseEncoder
-from sentence_transformers.sparse_encoder.search_engines import semantic_search_qdrant
+from sentence_transformers.sparse_encoder.search_engines import semantic_search_seismic
 
 # 1. Load the natural-questions dataset with 100K answers
 dataset = load_dataset("sentence-transformers/natural-questions", split="train")
@@ -30,9 +26,8 @@ queries = dataset["query"][:2]
 sparse_model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
 
 # 4. Encode the corpus
-corpus_embeddings = sparse_model.encode(corpus, convert_to_sparse_tensor=True, batch_size=16, show_progress_bar=True)
+corpus_embeddings = sparse_model.encode(corpus, convert_to_sparse_tensor=True, batch_size=32, show_progress_bar=True)
 
-# Initially, we don't have a qdrant index yet
 corpus_index = None
 while True:
     # 5. Encode the queries using the full precision
@@ -41,7 +36,7 @@ while True:
     print(f"Encoding time: {time.time() - start_time:.6f} seconds")
 
     # 6. Perform semantic search using qdrant
-    results, search_time, corpus_index = semantic_search_qdrant(
+    results, search_time, corpus_index = semantic_search_seismic(
         query_embeddings,
         corpus_index=corpus_index,
         corpus_embeddings=corpus_embeddings if corpus_index is None else None,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add Seismic semantic search example
* Add docs for the Seismic integration as well
* Fix the numbering in the semantic_search files
* Wrap all the TYPE_CHECKING imports with try-except ImportError (I think this is required if you have multiple TYPE_CHECKING imports and the first one fails, but I'm not 100% sure)

## Details
In my brief experiments, Seismic is indeed extremely fast. E.g. 2-3ms search compared to 9-27ms for Qdrant, and it doesn't require running a separate client. Having said that, it's definitely a young project and its documentation is still a bit rough. It also can't nicely be combined for hybrid search like Qdrant/ES can be, but it's amazing for projects for devs who want a more "manual" implementation of their search.

- Tom Aarsen