### PR TITLE
Add Sparse tags/model_type to model card automatically

### DIFF
--- a/examples/sparse_encoder/training/retrievers/train_splade_nq.py
+++ b/examples/sparse_encoder/training/retrievers/train_splade_nq.py
@@ -120,7 +120,7 @@ def main():
     except Exception:
         logging.error(
             f"Error uploading model to the Hugging Face Hub:\n{traceback.format_exc()}To upload it manually, you can run "
-            f"`huggingface-cli login`, followed by loading the model using `model = CrossEncoder({final_output_dir!r})` "
+            f"`huggingface-cli login`, followed by loading the model using `model = SparseEncoder({final_output_dir!r})` "
             f"and saving it using `model.push_to_hub('{run_name}')`."
         )
 

--- a/sentence_transformers/cross_encoder/model_card.py
+++ b/sentence_transformers/cross_encoder/model_card.py
@@ -70,6 +70,7 @@ class CrossEncoderModelCardData(SentenceTransformerModelCardData):
         default_factory=lambda: [
             "sentence-transformers",
             "cross-encoder",
+            "reranker",
         ]
     )
 
@@ -78,6 +79,7 @@ class CrossEncoderModelCardData(SentenceTransformerModelCardData):
 
     # Computed once, always unchanged
     pipeline_tag: str = field(default=None, init=False)
+    template_path: Path = field(default=Path(__file__).parent / "model_card_template.md", init=False, repr=False)
 
     # Passed via `register_model` only
     model: CrossEncoder | None = field(default=None, init=False, repr=False)
@@ -150,6 +152,7 @@ class CrossEncoderModelCardData(SentenceTransformerModelCardData):
 
 
 def generate_model_card(model: CrossEncoder) -> str:
-    template_path = Path(__file__).parent / "model_card_template.md"
-    model_card = ModelCard.from_template(card_data=model.model_card_data, template_path=template_path, hf_emoji="🤗")
+    model_card = ModelCard.from_template(
+        card_data=model.model_card_data, template_path=model.model_card_data.template_path, hf_emoji="🤗"
+    )
     return model_card.content

--- a/sentence_transformers/sparse_encoder/model_card_template.md
+++ b/sentence_transformers/sparse_encoder/model_card_template.md
@@ -4,14 +4,14 @@
 {{ card_data }}
 ---
 
-# {{ model_name if model_name else "Sparse Encoder model" }}
+# {{ model_name if model_name else ((model_type or "Sparse Encoder") + " model") }}
 
-This is a [Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model{% if base_model %} finetuned from [{{ base_model }}](https://huggingface.co/{{ base_model }}){% else %} trained{% endif %}{% if train_datasets | selectattr("name") | list %} on {% if train_datasets | selectattr("name") | map(attribute="name") | join(", ") | length > 200 %}{{ train_datasets | length }}{% else %}the {% for dataset in (train_datasets | selectattr("name")) %}{% if dataset.id %}[{{ dataset.name if dataset.name else dataset.id }}](https://huggingface.co/datasets/{{ dataset.id }}){% else %}{{ dataset.name }}{% endif %}{% if not loop.last %}{% if loop.index == (train_datasets | selectattr("name") | list | length - 1) %} and {% else %}, {% endif %}{% endif %}{% endfor %}{% endif %} dataset{{"s" if train_datasets | selectattr("name") | list | length > 1 else ""}}{% endif %} using the [sentence-transformers](https://www.SBERT.net) library. It maps sentences & paragraphs to a {{ output_dimensionality }}-dimensional sparse vector space and can be used for {{ task_name }}.
+This is a [{{ model_type or "Sparse Encoder" }}](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model{% if base_model %} finetuned from [{{ base_model }}](https://huggingface.co/{{ base_model }}){% else %} trained{% endif %}{% if train_datasets | selectattr("name") | list %} on {% if train_datasets | selectattr("name") | map(attribute="name") | join(", ") | length > 200 %}{{ train_datasets | length }}{% else %}the {% for dataset in (train_datasets | selectattr("name")) %}{% if dataset.id %}[{{ dataset.name if dataset.name else dataset.id }}](https://huggingface.co/datasets/{{ dataset.id }}){% else %}{{ dataset.name }}{% endif %}{% if not loop.last %}{% if loop.index == (train_datasets | selectattr("name") | list | length - 1) %} and {% else %}, {% endif %}{% endif %}{% endfor %}{% endif %} dataset{{"s" if train_datasets | selectattr("name") | list | length > 1 else ""}}{% endif %} using the [sentence-transformers](https://www.SBERT.net) library. It maps sentences & paragraphs to a {{ output_dimensionality }}-dimensional sparse vector space and can be used for {{ task_name }}.
 
 ## Model Details
 
 ### Model Description
-- **Model Type:** Sparse Encoder
+- **Model Type:** {{ model_type or "Sparse Encoder" }}
 {% if base_model -%}
     {%- if base_model_revision -%}
     - **Base model:** [{{ base_model }}](https://huggingface.co/{{ base_model }}) <!-- at revision {{ base_model_revision }} -->

--- a/sentence_transformers/sparse_encoder/models/IDF.py
+++ b/sentence_transformers/sparse_encoder/models/IDF.py
@@ -45,7 +45,7 @@ class IDF(InputModule):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer,
-        weight: torch.Tensor | None,
+        weight: torch.Tensor | None = None,
         frozen: bool = False,
     ):
         super().__init__()

--- a/tests/sparse_encoder/conftest.py
+++ b/tests/sparse_encoder/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from sentence_transformers import SparseEncoder
+
+
+@pytest.fixture()
+def splade_bert_tiny_model() -> SparseEncoder:
+    return SparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
+
+
+@pytest.fixture()
+def csr_bert_tiny_model() -> SparseEncoder:
+    return SparseEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")

--- a/tests/sparse_encoder/test_model_card.py
+++ b/tests/sparse_encoder/test_model_card.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import pytest
+
+from sentence_transformers import SparseEncoderTrainer
+from sentence_transformers.model_card import generate_model_card
+from sentence_transformers.util import is_datasets_available, is_training_available
+
+if is_datasets_available():
+    from datasets import Dataset, DatasetDict
+
+if not is_training_available():
+    pytest.skip(
+        reason='Sentence Transformers was not installed with the `["train"]` extra.',
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def dummy_dataset():
+    """
+    Dummy dataset for testing purposes. The dataset looks as follows:
+    {
+        "anchor": ["anchor 1", "anchor 2", ..., "anchor 10"],
+        "positive": ["positive 1", "positive 2", ..., "positive 10"],
+        "negative": ["negative 1", "negative 2", ..., "negative 10"],
+    }
+    """
+    return Dataset.from_dict(
+        {
+            "anchor": [f"anchor {i}" for i in range(1, 11)],
+            "positive": [f"positive {i}" for i in range(1, 11)],
+            "negative": [f"negative {i}" for i in range(1, 11)],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_fixture_name", "num_datasets", "expected_substrings"),
+    [
+        # 0 actually refers to just a single dataset
+        (
+            "splade_bert_tiny_model",
+            0,
+            [
+                "This is a [SPLADE Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sparse-encoder-testing/splade-bert-tiny-nq](https://huggingface.co/sparse-encoder-testing/splade-bert-tiny-nq)",
+                "**Maximum Sequence Length:** 512 tokens",
+                "**Output Dimensionality:** 30522 dimensions",
+                "**Similarity Function:** Dot Product",
+                "#### Unnamed Dataset",
+                "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
+                " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
+                "* Loss: [<code>SparseMultipleNegativesRankingLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#sparsemultiplenegativesrankingloss) with these parameters:",
+            ],
+        ),
+        (
+            "splade_bert_tiny_model",
+            1,
+            [
+                "This is a [SPLADE Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sparse-encoder-testing/splade-bert-tiny-nq](https://huggingface.co/sparse-encoder-testing/splade-bert-tiny-nq) on the train_0 dataset using the [sentence-transformers](https://www.SBERT.net) library.",
+                "#### train_0",
+            ],
+        ),
+        (
+            "splade_bert_tiny_model",
+            2,
+            [
+                "This is a [SPLADE Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sparse-encoder-testing/splade-bert-tiny-nq](https://huggingface.co/sparse-encoder-testing/splade-bert-tiny-nq) on the train_0 and train_1 datasets using the [sentence-transformers](https://www.SBERT.net) library.",
+                "#### train_0",
+                "#### train_1",
+            ],
+        ),
+        (
+            "splade_bert_tiny_model",
+            10,
+            [
+                "This is a [SPLADE Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sparse-encoder-testing/splade-bert-tiny-nq](https://huggingface.co/sparse-encoder-testing/splade-bert-tiny-nq) on the train_0, train_1, train_2, train_3, train_4, train_5, train_6, train_7, train_8 and train_9 datasets using the [sentence-transformers](https://www.SBERT.net) library.",
+                "<details><summary>train_0</summary>",  # We start using <details><summary> if we have more than 3 datasets
+                "#### train_0",
+                "</details>\n<details><summary>train_9</summary>",
+                "#### train_9",
+            ],
+        ),
+        # We start using "50 datasets" when the ", "-joined dataset name exceed 200 characters
+        (
+            "splade_bert_tiny_model",
+            50,
+            [
+                "This is a [SPLADE Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sparse-encoder-testing/splade-bert-tiny-nq](https://huggingface.co/sparse-encoder-testing/splade-bert-tiny-nq) on 50 datasets using the [sentence-transformers](https://www.SBERT.net) library.",
+                "<details><summary>train_0</summary>",
+                "#### train_0",
+                "</details>\n<details><summary>train_49</summary>",
+                "#### train_49",
+            ],
+        ),
+        (
+            "csr_bert_tiny_model",
+            0,
+            [
+                "This is a [CSR Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sentence-transformers-testing/stsb-bert-tiny-safetensors](https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors) using the [sentence-transformers](https://www.SBERT.net) library.",
+                "**Maximum Sequence Length:** 512 tokens",
+                "**Output Dimensionality:** 512 dimensions",
+                "**Similarity Function:** Dot Product",
+                "#### Unnamed Dataset",
+                "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
+                " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
+                "* Loss: [<code>SparseMultipleNegativesRankingLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#sparsemultiplenegativesrankingloss) with these parameters:",
+            ],
+        ),
+    ],
+)
+def test_model_card_base(
+    model_fixture_name: str,
+    dummy_dataset: Dataset,
+    num_datasets: int,
+    expected_substrings: list[str],
+    request: pytest.FixtureRequest,
+) -> None:
+    model = request.getfixturevalue(model_fixture_name)
+
+    train_dataset = dummy_dataset
+    if num_datasets:
+        train_dataset = DatasetDict({f"train_{i}": train_dataset for i in range(num_datasets)})
+
+    # This adds data to model.model_card_data
+    SparseEncoderTrainer(
+        model,
+        train_dataset=train_dataset,
+    )
+
+    model_card = generate_model_card(model)
+
+    # For debugging purposes, we can save the model card to a file
+    # with open(f"test_model_card_{model_fixture_name}_{num_datasets}d.md", "w", encoding="utf8") as f:
+    #     f.write(model_card)
+
+    for substring in expected_substrings:
+        assert substring in model_card
+
+    # We don't want to have two consecutive empty lines anywhere
+    assert "\n\n\n" not in model_card


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add Sparse tags/model_type to model card automatically + tests
* Patch IDF: a `= None` was missing
* Typo: CrossEncoder in SparseEncoder script
* Set `repr=False` for `template_path` so it's not printed
* Add tags for the model card data defaults ("dense", "sparse", "reranker")
* When training with `Asym`, there's an issue in the widget sentence selection, I fixed that

Feel free to let me know what you think @arthurbr11 

- Tom Aarsen