### PR TITLE
[`model-card`] Use string texts as widget examples if feature-extraction

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -512,7 +512,7 @@ class SentenceTransformerModelCardData(CardData):
                     )
                 else:
                     # If we have e.g. feature-extraction, we just want individual sentences
-                    self.widget.append(random.choice(sentences))
+                    self.widget.append({"text": random.choice(sentences)})
                 self.predict_example = sentences[:3]
 
     def set_evaluation_metrics(

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -503,9 +503,16 @@ class SentenceTransformerModelCardData(CardData):
                     list(sentence.values())[0] if isinstance(sentence, dict) else sentence for sentence in sentences
                 ]
 
-                self.widget.append(
-                    {"source_sentence": sentences[0], "sentences": random.sample(sentences[1:], k=len(sentences) - 1)}
-                )
+                if self.pipeline_tag == "sentence-similarity":
+                    self.widget.append(
+                        {
+                            "source_sentence": sentences[0],
+                            "sentences": random.sample(sentences[1:], k=len(sentences) - 1),
+                        }
+                    )
+                else:
+                    # If we have e.g. feature-extraction, we just want individual sentences
+                    self.widget.append(random.choice(sentences))
                 self.predict_example = sentences[:3]
 
     def set_evaluation_metrics(

--- a/sentence_transformers/sparse_encoder/model_card.py
+++ b/sentence_transformers/sparse_encoder/model_card.py
@@ -8,15 +8,11 @@ from typing import TYPE_CHECKING, Any
 from sentence_transformers.model_card import SentenceTransformerModelCardCallback, SentenceTransformerModelCardData
 from sentence_transformers.models import Asym, Module
 from sentence_transformers.sparse_encoder.models import IDF, CSRSparsity, SpladePooling
-from sentence_transformers.util import is_datasets_available
-
-if is_datasets_available():
-    pass
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentence_transformers.sparse_encoder.SparseEncoder import SparseEncoder
+
+logger = logging.getLogger(__name__)
 
 
 class SparseEncoderModelCardCallback(SentenceTransformerModelCardCallback):


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use string texts as widget examples if feature-extraction
* Removed some dead code in sparse_encoder `model_card.py`, move `logger` a bit.

## Details
The `source_sentence` and `sentences` from the `widget` in the model card is linked to the `sentence-similarity` pipeline tag:

![image](https://github.com/user-attachments/assets/241c2689-b0cd-498e-b008-c248db712ec3)

And when we're using `feature-extraction` instead, I believe we should just have "normal" texts instead of this specific format.

![image](https://github.com/user-attachments/assets/5cbec61f-d58f-4698-8e13-5f721127e0e3)


- Tom Aarsen