### PR TITLE
[`model card`] Fall back to normal tokenization if kwargs fails

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -595,7 +595,7 @@ class SentenceTransformerModelCardData(CardData):
     def tokenize(self, text: str | list[str], **kwargs) -> dict[str, Any]:
         try:
             return self.model.tokenize(text, **kwargs)
-        except Exception:
+        except TypeError:
             # Fallback for backwards compatibility with modules that don't yet support kwargs
             return self.model.tokenize(text)
 

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -593,7 +593,11 @@ class SentenceTransformerModelCardData(CardData):
         return [dataset_output]
 
     def tokenize(self, text: str | list[str], **kwargs) -> dict[str, Any]:
-        return self.model.tokenize(text, **kwargs)
+        try:
+            return self.model.tokenize(text, **kwargs)
+        except Exception:
+            # Fallback for backwards compatibility with modules that don't yet support kwargs
+            return self.model.tokenize(text)
 
     def compute_dataset_metrics(
         self,

--- a/sentence_transformers/sparse_encoder/model_card.py
+++ b/sentence_transformers/sparse_encoder/model_card.py
@@ -106,9 +106,6 @@ class SparseEncoderModelCardData(SentenceTransformerModelCardData):
         model_type += ["Sparse Encoder"]
         self.model_type = " ".join(model_type)
 
-    def tokenize(self, text: str | list[str], **kwargs) -> dict[str, Any]:
-        return self.model.tokenize(text, **kwargs)
-
     def get_model_specific_metadata(self) -> dict[str, Any]:
         similarity_fn_name = "Dot Product"
         if self.model.similarity_fn_name:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fall back to normal tokenization if kwargs fails

## Details
Our big PR updates the tokenization to accept `kwargs`, but it may fail as not all InputModules accept kwargs in their tokenization. For safety, this uses the old tokenization without kwargs as a backup. For model card generation, I want to be as safe as possible as it's rather frustrating if things fail here.

- Tom Aarsen