### PR TITLE
Fix method name for document encoding in model card templates

### DIFF
--- a/sentence_transformers/model_card_template.md
+++ b/sentence_transformers/model_card_template.md
@@ -113,7 +113,7 @@ documents = [
 {%- endfor %}
 ]
 query_embeddings = model.encode_query(queries)
-document_embeddings = model.encode_documents(documents)
+document_embeddings = model.encode_document(documents)
 print(query_embeddings.shape, document_embeddings.shape)
 # [1, {{ output_dimensionality | default(1024, true) }}] [{{ (predict_example | length) - 1 }}, {{ output_dimensionality | default(1024, true) }}]
 

--- a/sentence_transformers/sparse_encoder/model_card_template.md
+++ b/sentence_transformers/sparse_encoder/model_card_template.md
@@ -113,7 +113,7 @@ documents = [
 {%- endfor %}
 ]
 query_embeddings = model.encode_query(queries)
-document_embeddings = model.encode_documents(documents)
+document_embeddings = model.encode_document(documents)
 print(query_embeddings.shape, document_embeddings.shape)
 # [1, {{ output_dimensionality }}] [{{ (predict_example | length) - 1 }}, {{ output_dimensionality }}]
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix method name for document encoding in model card templates

## Details
I realised just now that `encode_documents` was accidentally used, instead of `encode_document`.

- Tom Aarsen