### PR TITLE
[`fix`] Make it easier for Sparse...Evaluator to know which encode_fn is used

### DIFF
--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -305,7 +305,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         query_embeddings = self.embed_inputs(
             model,
             self.queries,
-            encode_fn=model.encode_query,
+            encode_fn_name="query",
             prompt_name=self.query_prompt_name,
             prompt=self.query_prompt,
         )
@@ -325,7 +325,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
                 sub_corpus_embeddings = self.embed_inputs(
                     corpus_model,
                     self.corpus[corpus_start_idx:corpus_end_idx],
-                    encode_fn=corpus_model.encode_document,
+                    encode_fn_name="document",
                     prompt_name=self.corpus_prompt_name,
                     prompt=self.corpus_prompt,
                 )
@@ -405,11 +405,17 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         self,
         model: SentenceTransformer,
         sentences: str | list[str] | np.ndarray,
-        encode_fn: Callable[..., Tensor] = None,
+        encode_fn_name: str | None = None,
         prompt_name: str | None = None,
         prompt: str | None = None,
         **kwargs,
     ) -> np.ndarray:
+        if encode_fn_name is None:
+            encode_fn = model.encode
+        elif encode_fn_name == "query":
+            encode_fn = model.encode_query
+        elif encode_fn_name == "document":
+            encode_fn = model.encode_document
         return encode_fn(
             sentences,
             prompt_name=prompt_name,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseInformationRetrievalEvaluator.py
@@ -238,11 +238,17 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
         self,
         model: SparseEncoder,
         sentences: str | list[str] | np.ndarray,
-        encode_fn: Callable[..., torch.Tensor] = None,
+        encode_fn_name: str | None = None,
         prompt_name: str | None = None,
         prompt: str | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        if encode_fn_name is None:
+            encode_fn = model.encode
+        elif encode_fn_name == "query":
+            encode_fn = model.encode_query
+        elif encode_fn_name == "document":
+            encode_fn = model.encode_document
         embeddings = encode_fn(
             sentences,
             prompt_name=prompt_name,
@@ -255,7 +261,7 @@ class SparseInformationRetrievalEvaluator(InformationRetrievalEvaluator):
             **kwargs,
         )
         stat = model.sparsity(embeddings)
-        prefix = "query" if len(self.queries) == len(sentences) else "corpus"
+        prefix = "query" if encode_fn_name in ["query", None] else "corpus"
         for key, value in stat.items():
             self.sparsity_stats[prefix][key].append(value)
         if prefix == "corpus":


### PR DESCRIPTION
Hello!

## Pull Request overview
* Make it easier for Sparse...Evaluator to know which encode_fn is used

## Details
This specifically changes the IR and Reranking evaluators.

The old code crashes if there's the same amount of queries as documents, as corpus_lengths stays empty as all `encode` calls are considered for the query. This should be resolved now.

- Tom Aarsen