### PR TITLE
Dont store NanoBEIR scores in model card if just one dataset

### DIFF
--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -459,6 +459,13 @@ class NanoBEIREvaluator(SentenceEvaluator):
         if error_msg:
             raise ValueError(error_msg.strip())
 
+    def store_metrics_in_model_card_data(self, *args, **kwargs):
+        # Only store metrics in the model card data if there is more than one dataset.
+        # Otherwise the e.g. mean scores for NanoBEIR are the same as the scores for
+        # the single dataset, and we'd end up with duplicate entries.
+        if len(self.dataset_names) > 1:
+            super().store_metrics_in_model_card_data(*args, **kwargs)
+
     def get_config_dict(self) -> dict[str, Any]:
         config_dict = {"dataset_names": self.dataset_names}
         config_dict_candidate_keys = ["truncate_dim", "query_prompts", "corpus_prompts"]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Dont store NanoBEIR scores in model card if just one dataset

## Details
In short, if you only have one dataset, you'll get both the (Sparse) InformationRetrieval metrics section as well as the (Sparse) NanoBEIR metrics section in your model card. This is very duplicate, as they report exactly the same information. So, if you only have one dataset, then we don't store the NanoBEIR in the model card.
This only affects the model card, not e.g. the logged metrics or the evaluation keys used in `load_best_model_at_end`.

- Tom Aarsen