### PR TITLE
Clean up various losses

### DIFF
--- a/sentence_transformers/losses/DistillKLDivLoss.py
+++ b/sentence_transformers/losses/DistillKLDivLoss.py
@@ -124,7 +124,7 @@ class DistillKLDivLoss(nn.Module):
         super().__init__()
         self.model = model
         self.similarity_fct = similarity_fct
-        self.loss_fct = nn.KLDivLoss(reduction="none")
+        self.loss_fct = nn.KLDivLoss(reduction="batchmean")
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
@@ -133,43 +133,20 @@ class DistillKLDivLoss(nn.Module):
 
     def compute_loss_from_embeddings(self, embeddings: list[Tensor], labels: Tensor) -> Tensor:
         embeddings_query = embeddings[0]
-        embeddings_pos = embeddings[1]
-        embeddings_negs = embeddings[2:]
 
         # Compute student scores
-        student_scores_pos = self.similarity_fct(embeddings_query, embeddings_pos)
-        if len(embeddings_negs) == 1:
-            # Single negative case
-            student_scores_neg = self.similarity_fct(embeddings_query, embeddings_negs[0])
-        else:
-            # Multiple negatives case
-            student_scores_neg = torch.stack(
-                [self.similarity_fct(embeddings_query, neg) for neg in embeddings_negs],
-                dim=1,
-            )
-
-        # Teacher scores
-        teacher_pos_scores = labels[:, 0].unsqueeze(1)
-        teacher_neg_scores = labels[:, 1:]
-
-        # Prepare student scores to match teacher scores shape
-        student_scores_pos = student_scores_pos.unsqueeze(1)
-
-        # Create log probabilities for student scores
-        if len(embeddings_negs) == 1:
-            student_scores_neg = student_scores_neg.unsqueeze(1)
-            student_scores = torch.cat([student_scores_pos, student_scores_neg], dim=1)
-        else:
-            student_scores = torch.cat([student_scores_pos, student_scores_neg], dim=1)
-
+        student_scores = torch.stack(
+            [self.similarity_fct(embeddings_query, embeddings_other) for embeddings_other in embeddings[1:]],
+            dim=1,
+        )
         student_log_probs = torch.log_softmax(student_scores, dim=1)
 
-        # Create probabilities for teacher scores
-        teacher_scores = torch.cat([teacher_pos_scores, teacher_neg_scores], dim=1)
+        # Compute teacher scores
+        teacher_scores = labels
         teacher_probs = torch.softmax(teacher_scores, dim=1)
 
-        # KL Divergence
-        loss = self.loss_fct(student_log_probs, teacher_probs).sum(dim=1).mean()
+        # Compute the KL Divergence
+        loss = self.loss_fct(student_log_probs, teacher_probs)
         return loss
 
     @property

--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -180,7 +180,7 @@ class MarginMSELoss(nn.Module):
         # Handle both single and multiple negative cases
         if len(embeddings_negs) == 1:
             scores_neg = self.similarity_fct(embeddings_query, embeddings_negs[0])
-            margin_pred = scores_pos - scores_neg
+            margin_pred = (scores_pos - scores_neg).unsqueeze(1)
             return self.loss_fct(margin_pred, labels)
         else:
             # Multiple negatives case

--- a/sentence_transformers/sparse_encoder/losses/SpladeLoss.py
+++ b/sentence_transformers/sparse_encoder/losses/SpladeLoss.py
@@ -113,7 +113,12 @@ class SpladeLoss(nn.Module):
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         losses = {}
-        losses["base_loss"] = self.loss.compute_loss_from_embeddings(embeddings, labels)
+        base_loss = self.loss.compute_loss_from_embeddings(embeddings, labels)
+        if isinstance(base_loss, dict):
+            losses.update(base_loss)
+        else:
+            losses["base_loss"] = base_loss
+
         if self.all_docs:
             # If all_docs is True, we consider all the input to be of the same type and so under the same regularization
             corpus_loss = self.regularizer.compute_loss_from_embeddings(torch.cat(embeddings))


### PR DESCRIPTION
Hello!

## Pull Request overview
* Have SpladeLoss accept base losses that return dictionaries (i.e. loss components)
* Prevent warning for mismatching shapes in MarginMSELoss
* Simplify DistillKLDivLoss

## Details
The changes should not change anything, only remove warnings and simplify code.

I still can't get distillation with DistillKLDivLoss working nicely, it just goes straight to 0 active dims, even with small lambda's. I did train this with a Splade-v3-style strategy (a.k.a. DistillKLDivLoss + MarginMSE):
* https://huggingface.co/tomaarsen/splade-cocondenser-msmarco-kldiv-marginmse-minilm (from cocondenser)
* https://huggingface.co/tomaarsen/splade-cocondenser-selfdistil-msmarco-kldiv-marginmse-minilm (from selfdistil)

The co-condenser style one was worse than just training with MarginMSE. The selfdistil one got stronger, but only when increasing the active dims to 50 & 550 for queries/documents.

Training script: https://huggingface.co/tomaarsen/splade-cocondenser-msmarco-kldiv-marginmse-minilm/blob/main/train_script.py

- Tom Aarsen