### PR TITLE
[`tests`] Adding more tests for `SparseEncoder`

### DIFF
--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -1230,13 +1230,13 @@ class SparseEncoder(SentenceTransformer):
         self,
         embeddings_1: torch.Tensor,
         embeddings_2: torch.Tensor,
-    ):
+    ) -> Tensor:
         """
         Compute the intersection of two sparse embeddings.
 
         Args:
-            embeddings_1 (torch.Tensor): First embedding tensor (vocab).
-            embeddings_2 (torch.Tensor): Second embedding tensor (batch_2, vocab).
+            embeddings_1 (torch.Tensor): First embedding tensor, (vocab).
+            embeddings_2 (torch.Tensor): Second embedding tensor, (vocab) or (batch_size, vocab).
 
         Returns:
             torch.Tensor: Intersection of the two embeddings.

--- a/sentence_transformers/sparse_encoder/__init__.py
+++ b/sentence_transformers/sparse_encoder/__init__.py
@@ -11,4 +11,3 @@ __all__ = [
     "SparseEncoderTrainingArguments",
     "SparseEncoderModelCardData",
 ]
-# TODO : Add tests for all the components

--- a/sentence_transformers/sparse_encoder/losses/__init__.py
+++ b/sentence_transformers/sparse_encoder/losses/__init__.py
@@ -26,4 +26,3 @@ __all__ = [
     "FlopsLoss",
     "SpladeLoss",
 ]
-# TODO: Test cached losses


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add more tests for untested areas of the `SparseEncoder`
* Also update typing/docstring for intersection

## Details
This should help with the coverage of the `SparseEncoder`. I'm okay with the lower coverage of the other components (losses, evaluation, even trainer/args because it's mostly just subclassed from ST).

- Tom Aarsen