### PR TITLE
Refactor linked to minor comments 

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -436,7 +436,7 @@ class Transformer(InputModule):
         )
 
     def __repr__(self) -> str:
-        return f"Transformer({self.get_config_dict()}) with Transformer model: {self.auto_model.__class__.__name__} "
+        return f"Transformer({dict(self.get_config_dict(), architectures=self.auto_model.__class__.__name__)})"
 
     def forward(self, features: dict[str, torch.Tensor], **kwargs) -> dict[str, torch.Tensor]:
         """Returns token_embeddings, cls_token"""

--- a/sentence_transformers/sparse_encoder/models/MLMTransformer.py
+++ b/sentence_transformers/sparse_encoder/models/MLMTransformer.py
@@ -157,7 +157,7 @@ class MLMTransformer(InputModule):
         return self.auto_model.config.vocab_size
 
     def __repr__(self) -> str:
-        return f"MLMTransformer({self.get_config_dict()}) with MLMTransformer model: {self.auto_model.__class__.__name__} "
+        return f"MLMTransformer({dict(self.get_config_dict(), architectures=self.auto_model.__class__.__name__)})"
 
     def save(self, output_path: str, safe_serialization: bool = True, **kwargs) -> None:
         self.auto_model.save_pretrained(output_path, safe_serialization=safe_serialization)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Refactor linked to the comments on the main PR [here](https://github.com/arthurbr11/sentence-transformers/pull/1#issuecomment-3000666188) 

## Details
Notably:

- [ ]  Refactor of `__repr__` function for `Transformer` and `MLMTransformer`
- [ ]  Add the possibility to add 2 `regularizer` in `SpladeLoss`
- [ ]  Rename `CSRSparsity` to `SparseAutoEncoder` and all associated doc and code that refer to it 
- [ ]  Rename `IDF` to something (still TBD) and all associated doc and code that refer to it (and HF hub PR update too)


- Arthur BRESNU