### PR TITLE
Add transformers_model property for easier access

### DIFF
--- a/examples/sentence_transformer/training/adaptive_layer/README.md
+++ b/examples/sentence_transformer/training/adaptive_layer/README.md
@@ -70,8 +70,8 @@ from sentence_transformers import SentenceTransformer
 
 model = SentenceTransformer("tomaarsen/mpnet-base-nli-adaptive-layer")
 
-# We can access the underlying model with `model[0].auto_model`
-print(model[0].auto_model)
+# We can access the underlying model with `model.transformers_model`
+print(model.transformers_model)
 ```
 ```
 MPNetModel(
@@ -114,11 +114,11 @@ MPNetModel(
   )
 )
 ```
-This output will differ depending on the model. We will look for the repeated layers in the encoder. For this MPNet model, this is stored under `model[0].auto_model.encoder.layer`. Then we can slice the model to only keep the first few layers to speed up the model:
+This output will differ depending on the model. We will look for the repeated layers in the encoder. For this MPNet model, this is stored under `model.transformers_model.encoder.layer`. Then we can slice the model to only keep the first few layers to speed up the model:
 
 ```python
 new_num_layers = 3
-model[0].auto_model.encoder.layer = model[0].auto_model.encoder.layer[:new_num_layers]
+model.transformers_model.encoder.layer = model.transformers_model.encoder.layer[:new_num_layers]
 ```
 
 Then we can run inference with it using <a href="../../../../docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode"><code>SentenceTransformers.encode</code></a>. 
@@ -128,7 +128,7 @@ from sentence_transformers import SentenceTransformer
 
 model = SentenceTransformer("tomaarsen/mpnet-base-nli-adaptive-layer")
 new_num_layers = 3
-model[0].auto_model.encoder.layer = model[0].auto_model.encoder.layer[:new_num_layers]
+model.transformers_model.encoder.layer = model.transformers_model.encoder.layer[:new_num_layers]
 
 embeddings = model.encode(
     [

--- a/sentence_transformers/backend.py
+++ b/sentence_transformers/backend.py
@@ -69,7 +69,6 @@ def export_optimized_onnx_model(
         None
     """
     from sentence_transformers import CrossEncoder, SentenceTransformer
-    from sentence_transformers.models.Transformer import Transformer
 
     try:
         from optimum.onnxruntime import ORTModelForFeatureExtraction, ORTModelForSequenceClassification, ORTOptimizer
@@ -84,8 +83,7 @@ def export_optimized_onnx_model(
     viable_st_model = (
         isinstance(model, SentenceTransformer)
         and len(model)
-        and isinstance(model[0], Transformer)
-        and isinstance(model[0].auto_model, ORTModelForFeatureExtraction)
+        and isinstance(model.transformers_model, ORTModelForFeatureExtraction)
     )
     viable_ce_model = isinstance(model, CrossEncoder) and isinstance(model.model, ORTModelForSequenceClassification)
     if not (viable_st_model or viable_ce_model):
@@ -94,7 +92,7 @@ def export_optimized_onnx_model(
         )
 
     if viable_st_model:
-        ort_model: ORTModelForFeatureExtraction = model[0].auto_model
+        ort_model: ORTModelForFeatureExtraction = model.transformers_model
     else:
         ort_model: ORTModelForSequenceClassification = model.model
     optimizer = ORTOptimizer.from_pretrained(ort_model)
@@ -162,7 +160,6 @@ def export_dynamic_quantized_onnx_model(
         None
     """
     from sentence_transformers import CrossEncoder, SentenceTransformer
-    from sentence_transformers.models.Transformer import Transformer
 
     try:
         from optimum.onnxruntime import ORTModelForFeatureExtraction, ORTModelForSequenceClassification, ORTQuantizer
@@ -177,8 +174,7 @@ def export_dynamic_quantized_onnx_model(
     viable_st_model = (
         isinstance(model, SentenceTransformer)
         and len(model)
-        and isinstance(model[0], Transformer)
-        and isinstance(model[0].auto_model, ORTModelForFeatureExtraction)
+        and isinstance(model.transformers_model, ORTModelForFeatureExtraction)
     )
     viable_ce_model = isinstance(model, CrossEncoder) and isinstance(model.model, ORTModelForSequenceClassification)
     if not (viable_st_model or viable_ce_model):
@@ -187,7 +183,7 @@ def export_dynamic_quantized_onnx_model(
         )
 
     if viable_st_model:
-        ort_model: ORTModelForFeatureExtraction = model[0].auto_model
+        ort_model: ORTModelForFeatureExtraction = model.transformers_model
     else:
         ort_model: ORTModelForSequenceClassification = model.model
     quantizer = ORTQuantizer.from_pretrained(ort_model)
@@ -265,7 +261,6 @@ def export_static_quantized_openvino_model(
         None
     """
     from sentence_transformers import CrossEncoder, SentenceTransformer
-    from sentence_transformers.models.Transformer import Transformer
 
     try:
         from optimum.intel import (
@@ -288,8 +283,7 @@ def export_static_quantized_openvino_model(
     viable_st_model = (
         isinstance(model, SentenceTransformer)
         and len(model)
-        and isinstance(model[0], Transformer)
-        and isinstance(model[0].auto_model, OVModelForFeatureExtraction)
+        and isinstance(model.transformers_model, OVModelForFeatureExtraction)
     )
     viable_ce_model = isinstance(model, CrossEncoder) and isinstance(model.model, OVModelForSequenceClassification)
     if not (viable_st_model or viable_ce_model):
@@ -301,7 +295,7 @@ def export_static_quantized_openvino_model(
         quantization_config = OVQuantizationConfig()
 
     if viable_st_model:
-        ov_model: OVModelForFeatureExtraction = model[0].auto_model
+        ov_model: OVModelForFeatureExtraction = model.transformers_model
     else:
         ov_model: OVModelForSequenceClassification = model.model
     ov_config = OVConfig(quantization_config=quantization_config)

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -905,6 +905,30 @@ class CrossEncoder(nn.Module, PushToHubMixin, FitMixin):
         return folder_url.commit_url
 
     @property
+    def transformers_model(self) -> PreTrainedModel | None:
+        """
+        Property to get the underlying transformers PreTrainedModel instance.
+
+        Returns:
+            PreTrainedModel or None: The underlying transformers model or None if not found.
+
+        Example:
+            ::
+
+                from sentence_transformers import CrossEncoder
+
+                model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2")
+
+                # You can now access the underlying transformers model
+                transformers_model = model.transformers_model
+                print(type(transformers_model))
+                # => <class 'transformers.models.bert.modeling_bert.BertForSequenceClassification'>
+        """
+        # This property simply points to self.model, it exists primarily to have the same interface
+        # as SentenceTransformer and SparseEncoder models.
+        return self.model
+
+    @property
     def _target_device(self) -> torch.device:
         logger.warning(
             "`CrossEncoder._target_device` has been removed, please use `CrossEncoder.device` instead.",

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -83,7 +83,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
         self.encoder = model  # This will be the final model used during the inference time.
         self.tokenizer_encoder = model.tokenizer
 
-        encoder_name_or_path = model[0].auto_model.config._name_or_path
+        encoder_name_or_path = model.transformers_model.config._name_or_path
         if decoder_name_or_path is None:
             assert (
                 tie_encoder_decoder
@@ -107,7 +107,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
                 f'Model name or path "{decoder_name_or_path}" does not support being as a decoder. Please make sure the decoder model has an "XXXLMHead" class.'
             )
             raise e
-        assert model[0].auto_model.config.hidden_size == decoder_config.hidden_size, "Hidden sizes do not match!"
+        assert model.transformers_model.config.hidden_size == decoder_config.hidden_size, "Hidden sizes do not match!"
         if self.tokenizer_decoder.pad_token is None:
             # Needed by GPT-2, etc.
             self.tokenizer_decoder.pad_token = self.tokenizer_decoder.eos_token
@@ -130,14 +130,14 @@ class DenoisingAutoEncoderLoss(nn.Module):
             try:
                 # Compatibility with transformers <4.40.0
                 PreTrainedModel._tie_encoder_decoder_weights(
-                    model[0].auto_model,
+                    model.transformers_model,
                     self.decoder._modules[decoder_base_model_prefix],
                     self.decoder.base_model_prefix,
                 )
             except TypeError:
                 # Compatibility with transformers >=4.40.0
                 PreTrainedModel._tie_encoder_decoder_weights(
-                    model[0].auto_model,
+                    model.transformers_model,
                     self.decoder._modules[decoder_base_model_prefix],
                     self.decoder.base_model_prefix,
                     encoder_name_or_path,

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -29,7 +29,7 @@ from transformers.trainer_callback import TrainerControl, TrainerState
 from typing_extensions import deprecated
 
 from sentence_transformers import __version__ as sentence_transformers_version
-from sentence_transformers.models import Router, StaticEmbedding, Transformer
+from sentence_transformers.models import Router, StaticEmbedding
 from sentence_transformers.training_args import SentenceTransformerTrainingArguments
 from sentence_transformers.util import fullname, is_accelerate_available, is_datasets_available
 
@@ -858,8 +858,8 @@ class SentenceTransformerModelCardData(CardData):
                 self.tags.append(tag)
 
     def try_to_set_base_model(self) -> None:
-        if isinstance(self.model[0], Transformer):
-            base_model = self.model[0].auto_model.config._name_or_path
+        if (transformers_model := self.model.transformers_model) is not None:
+            base_model = transformers_model.config._name_or_path
             base_model_path = Path(base_model)
             # Sometimes the name_or_path ends exactly with the model_id, e.g.
             # "C:\\Users\\tom/.cache\\torch\\sentence_transformers\\BAAI_bge-small-en-v1.5\\"

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -142,7 +142,7 @@ class Transformer(InputModule):
                 # TODO: Consider following these steps automatically so we can load PEFT models with other backends
                 raise ValueError(
                     "PEFT models can currently only be loaded with the `torch` backend. "
-                    'To use other backends, load the model with `backend="torch"`, call `model[0].auto_model.merge_and_unload()`, '
+                    'To use other backends, load the model with `backend="torch"`, call `model.transformers_model.merge_and_unload()`, '
                     "save that model with `model.save_pretrained()` and then load the model with the desired backend."
                 )
             from peft import PeftConfig

--- a/sentence_transformers/peft_mixin.py
+++ b/sentence_transformers/peft_mixin.py
@@ -4,8 +4,6 @@ from functools import wraps
 
 from transformers.integrations.peft import PeftAdapterMixin as PeftAdapterMixinTransformers
 
-from .models import Transformer
-
 
 def peft_wrapper(func):
     """Wrapper to call the method on the auto_model with a check for PEFT compatibility."""
@@ -13,7 +11,7 @@ def peft_wrapper(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         self.check_peft_compatible_model()
-        method = getattr(self[0].auto_model, func.__name__)
+        method = getattr(self.transformers_model, func.__name__)
         return method(*args, **kwargs)
 
     return wrapper
@@ -31,7 +29,7 @@ class PeftAdapterMixin:
     """
 
     def has_peft_compatible_model(self) -> bool:
-        return isinstance(self[0], Transformer) and isinstance(self[0].auto_model, PeftAdapterMixinTransformers)
+        return isinstance(self.transformers_model, PeftAdapterMixinTransformers)
 
     def check_peft_compatible_model(self) -> None:
         if not self.has_peft_compatible_model():

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -11,6 +11,7 @@ import torch
 from torch import Tensor, nn
 from tqdm import trange
 from transformers import AutoConfig
+from transformers.modeling_utils import PreTrainedModel
 from typing_extensions import deprecated
 
 from sentence_transformers.models import Pooling, Transformer
@@ -1196,6 +1197,30 @@ class SparseEncoder(SentenceTransformer):
         Property to set the maximal input sequence length for the model. Longer inputs will be truncated.
         """
         self._first_module().max_seq_length = value
+
+    @property
+    def transformers_model(self) -> PreTrainedModel | None:
+        """
+        Property to get the underlying transformers PreTrainedModel instance, if it exists.
+        Note that it's possible for a model to have multiple underlying transformers models, but this property
+        will return the first one it finds in the module hierarchy.
+
+        Returns:
+            PreTrainedModel or None: The underlying transformers model or None if not found.
+
+        Example:
+            ::
+
+                from sentence_transformers import SparseEncoder
+
+                model = SparseEncoder("naver/splade-v3")
+
+                # You can now access the underlying transformers model
+                transformers_model = model.transformers_model
+                print(type(transformers_model))
+                # => <class 'transformers.models.bert.modeling_bert.BertForMaskedLM'>
+        """
+        return super().transformers_model
 
     @property
     def splade_pooling_chunk_size(self) -> int | None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -39,7 +39,7 @@ def test_backend_export(backend, expected_auto_model_class, model_kwargs) -> Non
         "sentence-transformers-testing/stsb-bert-tiny-safetensors", backend=backend, model_kwargs=model_kwargs
     )
     assert model.get_backend() == backend
-    assert isinstance(model[0].auto_model, expected_auto_model_class)
+    assert isinstance(model.transformers_model, expected_auto_model_class)
     embedding = model.encode("Hello, World!")
     assert embedding.shape == (model.get_sentence_embedding_dimension(),)
 
@@ -56,7 +56,7 @@ def test_backend_no_export_crash():
     model = SentenceTransformer(
         "sentence-transformers-testing/stsb-bert-tiny-safetensors", backend="openvino", model_kwargs={"export": False}
     )
-    assert isinstance(model[0].auto_model, OVModelForFeatureExtraction)
+    assert isinstance(model.transformers_model, OVModelForFeatureExtraction)
 
 
 ## Testing loading exported models:
@@ -101,7 +101,10 @@ def test_openvino_provider() -> None:
         backend="openvino",
         model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "precision_1"}},
     )
-    assert model[0].auto_model.ov_config == {"INFERENCE_PRECISION_HINT": "precision_1", "PERFORMANCE_HINT": "LATENCY"}
+    assert model.transformers_model.ov_config == {
+        "INFERENCE_PRECISION_HINT": "precision_1",
+        "PERFORMANCE_HINT": "LATENCY",
+    }
 
     with tempfile.TemporaryDirectory() as temp_dir:
         ov_config_path = os.path.join(temp_dir, "ov_config.json")
@@ -113,7 +116,7 @@ def test_openvino_provider() -> None:
             backend="openvino",
             model_kwargs={"ov_config": ov_config_path},
         )
-        assert model[0].auto_model.ov_config == {
+        assert model.transformers_model.ov_config == {
             "INFERENCE_PRECISION_HINT": "precision_2",
             "PERFORMANCE_HINT": "LATENCY",
         }
@@ -148,7 +151,7 @@ def test_openvino_backend() -> None:
             model_kwargs={"ov_config": config_file},
         )
         # The transformers model is an Optimum model with an OpenVINO inference request property
-        assert openvino_model_with_config[0].auto_model.request.get_property("NUM_STREAMS") == 2
+        assert openvino_model_with_config.transformers_model.request.get_property("NUM_STREAMS") == 2
 
         # Test that saving and loading local OpenVINO models works as expected
         openvino_model_with_config.save_pretrained(tmpdirname)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -784,7 +784,7 @@ def test_safetensors(modules: list[nn.Module] | SentenceTransformer) -> None:
     else:
         # output_hidden_states must be True for WeightedLayerPooling
         if isinstance(modules[1], WeightedLayerPooling):
-            modules[0].auto_model.config.output_hidden_states = True
+            modules.transformers_model.config.output_hidden_states = True
         model = SentenceTransformer(modules=modules)
     original_embedding = model.encode("Hello, World!")
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `transformers_model` property for easier access

## Details
Let's avoid `self.model[0].auto_model` to try and find the underlying transformers `PreTrainedModel`. Should also solve https://github.com/UKPLab/sentence-transformers/pull/3365 & https://github.com/UKPLab/sentence-transformers/issues/3357.

- Tom Aarsen
