### PR TITLE
[`fix`] Fix resuming from checkpoint with PEFT models

### DIFF
--- a/examples/sentence_transformer/training/peft/README.md
+++ b/examples/sentence_transformer/training/peft/README.md
@@ -37,6 +37,7 @@ The :class:`~sentence_transformers.SentenceTransformer` supports 7 methods for i
    * :meth:`~sentence_transformers.SentenceTransformer.enable_adapters`: Enable all adapters.
    * :meth:`~sentence_transformers.SentenceTransformer.disable_adapters`: Disable all adapters.
    * :meth:`~sentence_transformers.SentenceTransformer.get_adapter_state_dict`: Get the adapter state dict with the weights.
+   * :meth:`~sentence_transformers.SentenceTransformer.delete_adapter`: Delete an adapter from the model.
 
 ```
 

--- a/examples/sentence_transformer/training/peft/training_gooaq_lora.py
+++ b/examples/sentence_transformer/training/peft/training_gooaq_lora.py
@@ -12,7 +12,7 @@ from sentence_transformers import (
     SentenceTransformerTrainingArguments,
 )
 from sentence_transformers.evaluation import NanoBEIREvaluator
-from sentence_transformers.losses import MultipleNegativesRankingLoss
+from sentence_transformers.losses import CachedMultipleNegativesRankingLoss
 from sentence_transformers.training_args import BatchSamplers
 
 # Set the log level to INFO to get more information
@@ -49,7 +49,7 @@ train_dataset: Dataset = dataset_dict["train"].select(range(1_000_000))
 eval_dataset: Dataset = dataset_dict["test"]
 
 # 4. Define a loss function
-loss = MultipleNegativesRankingLoss(model)
+loss = CachedMultipleNegativesRankingLoss(model, mini_batch_size=32)
 
 # 5. (Optional) Specify training arguments
 run_name = f"{model_name_only}-gooaq-peft"
@@ -78,7 +78,7 @@ args = SentenceTransformerTrainingArguments(
 
 # 6. (Optional) Create an evaluator & evaluate the base model
 # The full corpus, but only the evaluation queries
-dev_evaluator = NanoBEIREvaluator(batch_size=1024)
+dev_evaluator = NanoBEIREvaluator()
 dev_evaluator(model)
 
 # 7. Create a trainer & train

--- a/sentence_transformers/peft_mixin.py
+++ b/sentence_transformers/peft_mixin.py
@@ -25,7 +25,7 @@ class PeftAdapterMixin:
 
     Currently supported PEFT methods follow those supported by transformers library,
     you can find more information on:
-    https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin
+    https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin
     """
 
     def has_peft_compatible_model(self) -> bool:
@@ -48,10 +48,10 @@ class PeftAdapterMixin:
         Args:
             *args:
                 Positional arguments to pass to the underlying AutoModel `load_adapter` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.load_adapter
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.load_adapter
             **kwargs:
                 Keyword arguments to pass to the underlying AutoModel `load_adapter` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.load_adapter
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.load_adapter
         """
         ...  # Implementation handled by the wrapper
 
@@ -67,10 +67,10 @@ class PeftAdapterMixin:
         Args:
             *args:
                 Positional arguments to pass to the underlying AutoModel `add_adapter` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.add_adapter
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.add_adapter
             **kwargs:
                 Keyword arguments to pass to the underlying AutoModel `add_adapter` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.add_adapter
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.add_adapter
 
         """
         ...  # Implementation handled by the wrapper
@@ -83,10 +83,10 @@ class PeftAdapterMixin:
         Args:
             *args:
                 Positional arguments to pass to the underlying AutoModel `set_adapter` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.set_adapter
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.set_adapter
             **kwargs:
                 Keyword arguments to pass to the underlying AutoModel `set_adapter` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.set_adapter
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.set_adapter
         """
         ...  # Implementation handled by the wrapper
 
@@ -133,9 +133,26 @@ class PeftAdapterMixin:
         Args:
             *args:
                 Positional arguments to pass to the underlying AutoModel `get_adapter_state_dict` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.get_adapter_state_dict
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.get_adapter_state_dict
             **kwargs:
                 Keyword arguments to pass to the underlying AutoModel `get_adapter_state_dict` function. More information can be found in the transformers documentation
-                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.get_adapter_state_dict
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.get_adapter_state_dict
         """
         ...  # Implementation handled by the wrapper
+
+    @peft_wrapper
+    def delete_adapter(self, *args, **kwargs) -> None:
+        """
+        If you are not familiar with adapters and PEFT methods, we invite you to read more about them on the PEFT
+        official documentation: https://huggingface.co/docs/peft
+
+        Delete an adapter's LoRA layers from the underlying model.
+
+        Args:
+            *args:
+                Positional arguments to pass to the underlying AutoModel `delete_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.delete_adapter
+            **kwargs:
+                Keyword arguments to pass to the underlying AutoModel `delete_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/main_classes/peft#transformers.integrations.PeftAdapterMixin.delete_adapter
+        """

--- a/sentence_transformers/sparse_encoder/trainer.py
+++ b/sentence_transformers/sparse_encoder/trainer.py
@@ -401,12 +401,6 @@ class SparseEncoderTrainer(SentenceTransformerTrainer):
             model=model, inputs=inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
         )
 
-    def _load_from_checkpoint(self, checkpoint_path: str) -> None:
-        from sentence_transformers import SparseEncoder
-
-        loaded_model = SparseEncoder(checkpoint_path, trust_remote_code=self.model.trust_remote_code)
-        self.model.load_state_dict(loaded_model.state_dict())
-
     def get_optimizer_cls_and_kwargs(
         self, args: SparseEncoderTrainingArguments, model: SparseEncoder | None = None
     ) -> tuple[Any, Any]:

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -1010,10 +1010,29 @@ class SentenceTransformerTrainer(Trainer):
         torch.save(self.args, os.path.join(output_dir, TRAINING_ARGS_NAME))
 
     def _load_from_checkpoint(self, checkpoint_path: str) -> None:
-        from sentence_transformers import SentenceTransformer
+        model_class = self.model.__class__
+        loaded_model = model_class(checkpoint_path, trust_remote_code=self.model.trust_remote_code)
 
-        loaded_model = SentenceTransformer(checkpoint_path, trust_remote_code=self.model.trust_remote_code)
-        self.model.load_state_dict(loaded_model.state_dict())
+        # Let's try to load PEFT Adapters if they are present in the checkpoint.
+        try:
+            checkpoint_adapters = loaded_model.active_adapters()
+        except (ValueError, TypeError):
+            # If not, we can assume that the checkpoint is a full model without adapters,
+            # and we can move over the state dict directly.
+            self.model.load_state_dict(loaded_model.state_dict())
+        else:
+            # If we can load adapters, we should load them one by one, potentially removing
+            # identically named adapters from the model being trained.
+            # But first, because we might have non-transformers weights, we also non-strictly load the state dict
+            self.model.load_state_dict(loaded_model.state_dict(), strict=False)
+            try:
+                train_adapters = self.model.active_adapters()
+            except ValueError:
+                train_adapters = []
+            for adapter_idx, adapter_name in enumerate(checkpoint_adapters):
+                if adapter_name in train_adapters:
+                    self.model.delete_adapter(adapter_name)
+                self.model.load_adapter(checkpoint_path, adapter_name=adapter_name, is_trainable=(adapter_idx == 0))
 
     def _include_prompt_length(self) -> bool:
         """


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update how checkpoints are loaded in case of PEFT
* Add delete_adapter method
* Update links in docs
* Update LoRA example script (much more reasonable defaults)

## Details
This is unrelated to the Sparse PR, but I want to already get it working with Sparse out of the box as well, so that's why I'm building this on top of the sparse branch instead of the default branch.

Regarding the checkpoint loading: we now use load_adapter to load the adapter weights from the checkpoint model, as the checkpoint does correctly re-load the adapters. I believe this should work pretty smoothly, although there'll be some issues with e.g. using multiple transformer models in one go.

- Tom Aarsen